### PR TITLE
feat: add envPrefix nested env vars lists

### DIFF
--- a/_examples/README.md
+++ b/_examples/README.md
@@ -12,7 +12,7 @@ There are few target files:
   [`x_complex.md`](./x_complex.md) with `-env-prefix` argument;
   and [`complex-nostyle.html`](./complex-nostyle.html) which is HTML documentation without built-in styles.
 - [`envprefix.go`](./envprefix.go) showcases a nested config structure with the `envPrefix` tag for a structure field.
-  It generates [`envprefix.md`](./envprefix.md).
+  It generates [`envprefix.md`](./envprefix.md), [`envprefix.txt`](./envprefix.txt) and [`envprefix.html`](./envprefix.html).
 
 The examples directory also contains helper script files:
  - `build-examples.sh` - modify any example Go file and regenerate all documentation outputs by executing it via `./build-examples.sh`.

--- a/_examples/complex-nostyle.html
+++ b/_examples/complex-nostyle.html
@@ -23,21 +23,18 @@ It is trying to cover all the possible cases.</p>
     <li><code>HOSTS</code> (separated by "<code>:</code>", <strong>required</strong>) - Hosts is a list of hosts.</li>
     <li><code>WORDS</code> (comma-separated, from-file, default: <code>one,two,three</code>) - Words is just a list of words.</li>
     <li><code>COMMENT</code> (<strong>required</strong>, default: <code>This is a comment.</code>) - Just a comment.</li>
-
   </ul>
 
   <h2>NextConfig</h2>
 
   <ul>
     <li><code>MOUNT</code> (<strong>required</strong>) - Mount is a mount point.</li>
-
   </ul>
 
   <h2>FieldNames</h2>
 <p>FieldNames uses field names as env names.</p>
   <ul>
     <li><code>QUUX</code> - Quux is a field with a tag.</li>
-
   </ul>
 
       </article>

--- a/_examples/complex.html
+++ b/_examples/complex.html
@@ -89,21 +89,18 @@ It is trying to cover all the possible cases.</p>
     <li><code>HOSTS</code> (separated by "<code>:</code>", <strong>required</strong>) - Hosts is a list of hosts.</li>
     <li><code>WORDS</code> (comma-separated, from-file, default: <code>one,two,three</code>) - Words is just a list of words.</li>
     <li><code>COMMENT</code> (<strong>required</strong>, default: <code>This is a comment.</code>) - Just a comment.</li>
-
   </ul>
 
   <h2>NextConfig</h2>
 
   <ul>
     <li><code>MOUNT</code> (<strong>required</strong>) - Mount is a mount point.</li>
-
   </ul>
 
   <h2>FieldNames</h2>
 <p>FieldNames uses field names as env names.</p>
   <ul>
     <li><code>QUUX</code> - Quux is a field with a tag.</li>
-
   </ul>
 
       </article>

--- a/_examples/envprefix.go
+++ b/_examples/envprefix.go
@@ -1,15 +1,51 @@
 package main
 
+// Settings is the application settings.
+//
+//go:generate go run ../ -output envprefix.txt -format plaintext -type Settings
 //go:generate go run ../ -output envprefix.md -type Settings
+//go:generate go run ../ -output envprefix.html -format html -type Settings
 type Settings struct {
 	// Database is the database settings
 	Database Database `envPrefix:"DB_"`
+
+	// Server is the server settings
+	Server ServerConfig `envPrefix:"SERVER_"`
 
 	// Debug is the debug flag
 	Debug bool `env:"DEBUG"`
 }
 
+// Database is the database settings.
 type Database struct {
 	// Port is the port to connect to
 	Port Int `env:"PORT,required"`
+	// Host is the host to connect to
+	Host string `env:"HOST,notEmpty" envDefault:"localhost"`
+	// User is the user to connect as
+	User string `env:"USER"`
+	// Password is the password to use
+	Password string `env:"PASSWORD"`
+	// DisableTLS is the flag to disable TLS
+	DisableTLS bool `env:"DISABLE_TLS"`
+}
+
+// ServerConfig is the server settings.
+type ServerConfig struct {
+	// Port is the port to listen on
+	Port Int `env:"PORT,required"`
+
+	// Host is the host to listen on
+	Host string `env:"HOST,notEmpty" envDefault:"localhost"`
+
+	// Timeout is the timeout settings
+	Timeout TimeoutConfig `envPrefix:"TIMEOUT_"`
+}
+
+// TimeoutConfig is the timeout settings.
+type TimeoutConfig struct {
+	// Read is the read timeout
+	Read Int `env:"READ" envDefault:"30"`
+	// Write is the write timeout
+	Write Int `env:"WRITE" envDefault:"30"`
 }

--- a/_examples/envprefix.html
+++ b/_examples/envprefix.html
@@ -76,14 +76,31 @@ p {
       <article>
         <h1>Environment Variables</h1>
 
-  <h2>Config</h2>
-<p>Config is an example configuration structure.
-It is used to generate documentation for the configuration
-using the commands below.</p>
+  <h2>Settings</h2>
+<p>Settings is the application settings.</p>
   <ul>
-    <li><code>HOST</code> (separated by "<code>;</code>", <strong>required</strong>) - Hosts name of hosts to listen on.</li>
-    <li><code>PORT</code> (<strong>required</strong>, non-empty) - Port to listen on.</li>
-    <li><code>DEBUG</code> (default: <code>false</code>) - Debug mode enabled.</li>
+    <li>Database is the database settings.
+    <ul>
+    <li><code>DB_PORT</code> (<strong>required</strong>) - Port is the port to connect to</li>
+    <li><code>DB_HOST</code> (<strong>required</strong>, non-empty, default: <code>localhost</code>) - Host is the host to connect to</li>
+    <li><code>DB_USER</code> - User is the user to connect as</li>
+    <li><code>DB_PASSWORD</code> - Password is the password to use</li>
+    <li><code>DB_DISABLE_TLS</code> - DisableTLS is the flag to disable TLS</li>
+    </ul>
+  </li>
+    <li>ServerConfig is the server settings.
+    <ul>
+    <li><code>SERVER_PORT</code> (<strong>required</strong>) - Port is the port to listen on</li>
+    <li><code>SERVER_HOST</code> (<strong>required</strong>, non-empty, default: <code>localhost</code>) - Host is the host to listen on</li>
+    <li>TimeoutConfig is the timeout settings.
+    <ul>
+    <li><code>SERVER_TIMEOUT_READ</code> (default: <code>30</code>) - Read is the read timeout</li>
+    <li><code>SERVER_TIMEOUT_WRITE</code> (default: <code>30</code>) - Write is the write timeout</li>
+    </ul>
+  </li>
+    </ul>
+  </li>
+    <li><code>DEBUG</code> - Debug is the debug flag</li>
   </ul>
 
       </article>

--- a/_examples/envprefix.md
+++ b/_examples/envprefix.md
@@ -2,5 +2,18 @@
 
 ## Settings
 
- - `DB_PORT` (**required**) - Port is the port to connect to
+Settings is the application settings.
+
+ - Database is the database settings.
+   - `DB_PORT` (**required**) - Port is the port to connect to
+   - `DB_HOST` (**required**, non-empty, default: `localhost`) - Host is the host to connect to
+   - `DB_USER` - User is the user to connect as
+   - `DB_PASSWORD` - Password is the password to use
+   - `DB_DISABLE_TLS` - DisableTLS is the flag to disable TLS
+ - ServerConfig is the server settings.
+   - `SERVER_PORT` (**required**) - Port is the port to listen on
+   - `SERVER_HOST` (**required**, non-empty, default: `localhost`) - Host is the host to listen on
+   - TimeoutConfig is the timeout settings.
+     - `SERVER_TIMEOUT_READ` (default: `30`) - Read is the read timeout
+     - `SERVER_TIMEOUT_WRITE` (default: `30`) - Write is the write timeout
  - `DEBUG` - Debug is the debug flag

--- a/_examples/envprefix.txt
+++ b/_examples/envprefix.txt
@@ -1,0 +1,19 @@
+Environment Variables
+
+## Settings
+
+Settings is the application settings.
+
+ * Database is the database settings.
+   * `DB_PORT` (required) - Port is the port to connect to
+   * `DB_HOST` (required, non-empty, default: `localhost`) - Host is the host to connect to
+   * `DB_USER` - User is the user to connect as
+   * `DB_PASSWORD` - Password is the password to use
+   * `DB_DISABLE_TLS` - DisableTLS is the flag to disable TLS
+ * ServerConfig is the server settings.
+   * `SERVER_PORT` (required) - Port is the port to listen on
+   * `SERVER_HOST` (required, non-empty, default: `localhost`) - Host is the host to listen on
+   * TimeoutConfig is the timeout settings.
+     * `SERVER_TIMEOUT_READ` (default: `30`) - Read is the read timeout
+     * `SERVER_TIMEOUT_WRITE` (default: `30`) - Write is the write timeout
+ * `DEBUG` - Debug is the debug flag

--- a/debug.go
+++ b/debug.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+const debugLogs = false
+
+func debug(f string, args ...any) {
+	if !debugLogs {
+		return
+	}
+	fmt.Printf("DEBUG: "+f+"\n", args...)
+}

--- a/main.go
+++ b/main.go
@@ -66,9 +66,20 @@ func main() {
 	}
 }
 
-func getConfig() (appConfig, error) {
+type getConfigOpt func(f *flag.FlagSet)
+
+var getConfigSilent = func(f *flag.FlagSet) {
+	f.Usage = func() {}
+	nopWriter := os.NewFile(0, os.DevNull)
+	f.SetOutput(nopWriter)
+}
+
+func getConfig(opts ...getConfigOpt) (appConfig, error) {
 	var cfg appConfig
 	flagSet := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	for _, opt := range opts {
+		opt(flagSet)
+	}
 	if err := cfg.parseFlags(flagSet); err != nil {
 		flagSet.Usage()
 		return cfg, fmt.Errorf("invalid CLI args: %w", err)

--- a/main_test.go
+++ b/main_test.go
@@ -22,10 +22,7 @@ func TestConfig(t *testing.T) {
 		t.Setenv("GOFILE", "test.go")
 		t.Setenv("GOLINE", "42")
 
-		cfg, err := getConfig()
-		if err != nil {
-			t.Fatal("Invalid CLI args:", err)
-		}
+		cfg := getTestConfig(t, false)
 		if cfg.outputFileName != "test.md" {
 			t.Fatal("Invalid output file name")
 		}
@@ -60,20 +57,12 @@ func TestConfig(t *testing.T) {
 	})
 	t.Run("bad-args", func(t *testing.T) {
 		os.Args = []string{"cmd", "-type"}
-		_, err := getConfig()
-		if err == nil {
-			t.Fatal("Expect error for invalid CLI args")
-		}
-		t.Logf("Got error as expected: %v", err)
+		_ = getTestConfig(t, true)
 	})
 	t.Run("bad-env", func(t *testing.T) {
 		t.Setenv("GOFILE", "")
 		t.Setenv("GOLINE", "abc")
-		_, err := getConfig()
-		if err == nil {
-			t.Fatal("Expect error for invalid environment")
-		}
-		t.Logf("Got error as expected: %v", err)
+		_ = getTestConfig(t, true)
 	})
 }
 
@@ -160,4 +149,19 @@ func TestMainRun(t *testing.T) {
 		}
 		t.Logf("Got error as expected: %v", err)
 	})
+}
+
+func getTestConfig(t *testing.T, expectErr bool) appConfig {
+	t.Helper()
+
+	cfg, err := getConfig(getConfigSilent)
+	if expectErr {
+		if err == nil {
+			t.Fatal("Expect error for invalid CLI args")
+		}
+		t.Logf("Got error as expected: %v", err)
+	} else if err != nil {
+		t.Fatal("Invalid CLI args:", err)
+	}
+	return cfg
 }

--- a/render.go
+++ b/render.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"io"
+	"strings"
 
 	htmltmpl "html/template"
 	texttmpl "text/template"
@@ -25,6 +26,19 @@ type renderItem struct {
 	Expand   bool
 	NonEmpty bool
 	FromFile bool
+
+	children []renderItem
+	Indent   int
+}
+
+func (i renderItem) Children(indentInc int) []renderItem {
+	indent := i.Indent + indentInc
+	res := make([]renderItem, len(i.children))
+	for j, child := range i.children {
+		child.Indent = indent
+		res[j] = child
+	}
+	return res
 }
 
 type renderContext struct {
@@ -46,29 +60,50 @@ func newRenderContext(scopes []*EnvScope, envPrefix string, noStyles bool) rende
 			Items: make([]renderItem, len(scope.Vars)),
 		}
 		for j, item := range scope.Vars {
-			section.Items[j] = renderItem{
-				EnvName:      fmt.Sprintf("%s%s", envPrefix, item.Name),
-				Doc:          item.Doc,
-				EnvDefault:   item.Opts.Default,
-				EnvSeparator: item.Opts.Separator,
-				Required:     item.Opts.Required,
-				Expand:       item.Opts.Expand,
-				NonEmpty:     item.Opts.NonEmpty,
-				FromFile:     item.Opts.FromFile,
-			}
+			item := newRenderItem(item, envPrefix)
+			item.Indent = 1
+			section.Items[j] = item
 		}
 		res.Sections[i] = section
 	}
 	return res
 }
 
+func newRenderItem(item EnvDocItem, envPrefix string) renderItem {
+	children := make([]renderItem, len(item.Children))
+	debug("render item %s", item.Name)
+	for i, child := range item.Children {
+		debug("render child item %s", child.Name)
+		children[i] = newRenderItem(child, envPrefix)
+	}
+	return renderItem{
+		EnvName:      fmt.Sprintf("%s%s", envPrefix, item.Name),
+		Doc:          item.Doc,
+		EnvDefault:   item.Opts.Default,
+		EnvSeparator: item.Opts.Separator,
+		Required:     item.Opts.Required,
+		Expand:       item.Opts.Expand,
+		NonEmpty:     item.Opts.NonEmpty,
+		FromFile:     item.Opts.FromFile,
+		children:     children,
+	}
+}
+
 //go:embed templ
 var templates embed.FS
 
+var tplFuncs = map[string]any{
+	"repeat": strings.Repeat,
+}
+
+func _() {
+	// texttmpl.ParseFS
+}
+
 var (
-	tmplMarkdown  = texttmpl.Must(texttmpl.ParseFS(templates, "templ/markdown.tmpl"))
-	tmplHTML      = htmltmpl.Must(htmltmpl.ParseFS(templates, "templ/html.tmpl"))
-	tmplPlaintext = texttmpl.Must(texttmpl.ParseFS(templates, "templ/plaintext.tmpl"))
+	tmplMarkdown  = texttmpl.Must(texttmpl.New("markdown.tmpl").Funcs(tplFuncs).ParseFS(templates, "templ/markdown.tmpl"))
+	tmplHTML      = htmltmpl.Must(htmltmpl.New("html.tmpl").Funcs(tplFuncs).ParseFS(templates, "templ/html.tmpl"))
+	tmplPlaintext = texttmpl.Must(texttmpl.New("plaintext.tmpl").Funcs(tplFuncs).ParseFS(templates, "templ/plaintext.tmpl"))
 )
 
 type template interface {

--- a/templ/html.tmpl
+++ b/templ/html.tmpl
@@ -1,3 +1,54 @@
+{{- define "item" }}
+    <li>
+    {{- $comma := false -}}
+    {{- if .EnvName -}}
+      <code>{{ .EnvName }}</code>
+      {{- if eq .EnvSeparator "," -}}
+        {{- $comma = true }} (comma-separated
+      {{- else if ne .EnvSeparator "" -}}
+        {{- $comma = true }} (separated by "<code>{{.EnvSeparator}}</code>"
+      {{- end -}}
+      {{- if .Required -}}
+        {{- if $comma }}, {{ else }} ({{ end -}}
+        {{- $comma = true -}}
+        <strong>required</strong>
+      {{- end -}}
+      {{- if .Expand -}}
+        {{- if $comma }}, {{ else }} ({{ end -}}
+        {{- $comma = true -}}
+        expand
+      {{- end -}}
+      {{- if .NonEmpty -}}
+        {{- if $comma }}, {{ else }} ({{ end -}}
+        {{- $comma = true -}}
+        non-empty
+      {{- end -}}
+      {{if .FromFile -}}
+        {{- if $comma }}, {{ else }} ({{ end -}}
+        {{- $comma = true -}}
+        from-file
+      {{- end -}}
+      {{- if ne .EnvDefault "" -}}
+        {{- if $comma }}, {{ else }} ({{ end -}}
+        {{- $comma = true -}}
+        default: <code>{{ .EnvDefault }}</code>
+      {{- end -}}
+      {{- if $comma }}){{ end -}}
+      {{- .Doc | printf " - %s" -}}
+    {{- else -}}
+      {{- .Doc | printf "%s" -}}
+    {{- end}}
+  {{- $children := .Children 0 -}}
+  {{- if $children }}
+    <ul>
+    {{- range $children -}}
+      {{ template "item" . -}}
+    {{- end }}
+    </ul>
+  {{ end -}}
+    </li>
+{{- end -}}
+
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -83,42 +134,8 @@ p {
 <p>{{ .Doc }}</p>
 {{- end }}
   <ul>
-{{ range .Items }}    <li>
-    {{- $comma := false -}}
-    <code>{{ .EnvName }}</code>
-    {{- if eq .EnvSeparator "," -}}
-      {{- $comma = true }} (comma-separated
-    {{- else if ne .EnvSeparator "" -}}
-      {{- $comma = true }} (separated by "<code>{{.EnvSeparator}}</code>"
-    {{- end -}}
-    {{- if .Required -}}
-      {{- if $comma }}, {{ else }} ({{ end -}}
-      {{- $comma = true -}}
-      <strong>required</strong>
-    {{- end -}}
-    {{- if .Expand -}} 
-      {{- if $comma }}, {{ else }} ({{ end -}}
-      {{- $comma = true -}}
-      expand
-    {{- end -}}
-    {{- if .NonEmpty -}}
-      {{- if $comma }}, {{ else }} ({{ end -}}
-      {{- $comma = true -}}
-      non-empty
-    {{- end -}}
-    {{if .FromFile -}}
-      {{- if $comma }}, {{ else }} ({{ end -}}
-      {{- $comma = true -}}
-      from-file
-    {{- end -}}
-    {{- if ne .EnvDefault "" -}}
-      {{- if $comma }}, {{ else }} ({{ end -}}
-      {{- $comma = true -}}
-      default: <code>{{ .EnvDefault }}</code>
-    {{- end -}}
-    {{- if $comma }}) {{ else }} {{ end -}}
- - {{ .Doc -}}
-    </li>
+{{- range .Items }}
+{{- template "item" . -}}
 {{ end }}
   </ul>
 {{ end }}

--- a/templ/markdown.tmpl
+++ b/templ/markdown.tmpl
@@ -1,3 +1,51 @@
+{{- define "item" }}
+  {{- $comma := false -}}
+  {{- repeat " " .Indent -}}
+  {{- if .EnvName }}
+    {{- .EnvName | printf "- `%s`" -}}
+    {{- if eq .EnvSeparator "," -}}
+      {{- $comma = true }} (comma-separated
+    {{- else if ne .EnvSeparator "" -}}
+      {{- $comma = true }} (separated by `{{.EnvSeparator}}`
+    {{- end -}}
+    {{- if .Required -}}
+      {{- if $comma }}, {{ else }} ({{ end -}}
+      {{- $comma = true -}}
+      **required**
+    {{- end -}}
+    {{- if .Expand -}}
+      {{- if $comma }}, {{ else }} ({{ end -}}
+      {{- $comma = true -}}
+      expand
+    {{- end -}}
+    {{- if .NonEmpty -}}
+      {{- if $comma }}, {{ else }} ({{ end -}}
+      {{- $comma = true -}}
+      non-empty
+    {{- end -}}
+    {{if .FromFile -}}
+      {{- if $comma }}, {{ else }} ({{ end -}}
+      {{- $comma = true -}}
+      from-file
+    {{- end -}}
+    {{- if ne .EnvDefault "" -}}
+      {{- if $comma }}, {{ else }} ({{ end -}}
+      {{- $comma = true -}}
+      {{- .EnvDefault | printf "default: `%s`" -}}
+    {{- end -}}
+    {{- if $comma }}){{ end -}}
+    {{- .Doc | printf " - %s"}}
+  {{- else }}
+    {{- .Doc | printf "- %s" }}
+  {{- end }}
+  {{- $children := .Children 2 }}
+  {{- if $children }}
+    {{- range $children }}
+{{ template "item" . }}
+    {{- end }}
+  {{- end -}}
+{{ end -}}
+
 # {{ .Title }}
 {{ range .Sections -}}
 {{ if ne .Name "" }}
@@ -7,39 +55,6 @@
 {{ .Doc }}
 {{ end }}
 {{ range .Items }}
-  {{- $comma := false -}}
-  {{- .EnvName | printf " - `%s`" -}}
-  {{- if eq .EnvSeparator "," -}}
-    {{- $comma = true }} (comma-separated
-  {{- else if ne .EnvSeparator "" -}}
-    {{- $comma = true }} (separated by `{{.EnvSeparator}}`
-  {{- end -}}
-  {{- if .Required -}}
-    {{- if $comma }}, {{ else }} ({{ end -}}
-    {{- $comma = true -}}
-    **required**
-  {{- end -}}
-  {{- if .Expand -}} 
-    {{- if $comma }}, {{ else }} ({{ end -}}
-    {{- $comma = true -}}
-    expand
-  {{- end -}}
-  {{- if .NonEmpty -}}
-    {{- if $comma }}, {{ else }} ({{ end -}}
-    {{- $comma = true -}}
-    non-empty
-  {{- end -}}
-  {{if .FromFile -}}
-    {{- if $comma }}, {{ else }} ({{ end -}}
-    {{- $comma = true -}}
-    from-file
-  {{- end -}}
-  {{- if ne .EnvDefault "" -}}
-    {{- if $comma }}, {{ else }} ({{ end -}}
-    {{- $comma = true -}}
-    {{- .EnvDefault | printf "default: `%s`" -}}
-  {{- end -}}
-  {{- if $comma }}) {{ else }} {{ end -}}
- - {{.Doc}}
+{{- template "item" . }}
 {{ end -}}
 {{ end -}}

--- a/templ/plaintext.tmpl
+++ b/templ/plaintext.tmpl
@@ -1,3 +1,51 @@
+{{- define "item" }}
+  {{- $comma := false -}}
+  {{- repeat " " .Indent -}}
+  {{- if .EnvName }}
+    {{- .EnvName | printf "* `%s`" -}}
+    {{- if eq .EnvSeparator "," -}}
+      {{- $comma = true }} (comma-separated
+    {{- else if ne .EnvSeparator "" -}}
+      {{- $comma = true }} (separated by `{{.EnvSeparator}}`
+    {{- end -}}
+    {{- if .Required -}}
+      {{- if $comma }}, {{ else }} ({{ end -}}
+      {{- $comma = true -}}
+      required
+    {{- end -}}
+    {{- if .Expand -}}
+      {{- if $comma }}, {{ else }} ({{ end -}}
+      {{- $comma = true -}}
+      expand
+    {{- end -}}
+    {{- if .NonEmpty -}}
+      {{- if $comma }}, {{ else }} ({{ end -}}
+      {{- $comma = true -}}
+      non-empty
+    {{- end -}}
+    {{if .FromFile -}}
+      {{- if $comma }}, {{ else }} ({{ end -}}
+      {{- $comma = true -}}
+      from-file
+    {{- end -}}
+    {{- if ne .EnvDefault "" -}}
+      {{- if $comma }}, {{ else }} ({{ end -}}
+      {{- $comma = true -}}
+      {{- .EnvDefault | printf "default: `%s`" -}}
+    {{- end -}}
+    {{- if $comma }}){{ end -}}
+    {{- .Doc | printf " - %s" }}
+  {{- else }}
+    {{- .Doc | printf "* %s" }}
+  {{- end }}
+  {{- $children := .Children 2 }}
+  {{- if $children }}
+    {{- range $children }}
+{{ template "item" . }}
+    {{- end }}
+  {{- end -}}
+{{ end -}}
+
 {{ .Title }}
 {{ range .Sections }}
 ## {{ .Name }}
@@ -5,39 +53,6 @@
 {{ .Doc }}
 {{ end }}
 {{ range .Items }}
-  {{- $comma := false -}}
-  {{- .EnvName | printf " * `%s`" -}}
-  {{- if eq .EnvSeparator "," -}}
-    {{- $comma = true }} (comma-separated
-  {{- else if ne .EnvSeparator "" -}}
-    {{- $comma = true }} (separated by `{{.EnvSeparator}}`
-  {{- end -}}
-  {{- if .Required -}}
-    {{- if $comma }}, {{ else }} ({{ end -}}
-    {{- $comma = true -}}
-    required
-  {{- end -}}
-  {{- if .Expand -}} 
-    {{- if $comma }}, {{ else }} ({{ end -}}
-    {{- $comma = true -}}
-    expand
-  {{- end -}}
-  {{- if .NonEmpty -}}
-    {{- if $comma }}, {{ else }} ({{ end -}}
-    {{- $comma = true -}}
-    non-empty
-  {{- end -}}
-  {{if .FromFile -}}
-    {{- if $comma }}, {{ else }} ({{ end -}}
-    {{- $comma = true -}}
-    from-file
-  {{- end -}}
-  {{- if ne .EnvDefault "" -}}
-    {{- if $comma }}, {{ else }} ({{ end -}}
-    {{- $comma = true -}}
-    {{- .EnvDefault | printf "default: `%s`" -}}
-  {{- end -}}
-  {{- if $comma }}) {{ else }} {{ end -}}
- - {{.Doc}}
+{{- template "item" . }}
 {{ end -}}
 {{ end -}}

--- a/testdata/envprefix.go
+++ b/testdata/envprefix.go
@@ -1,14 +1,47 @@
-package testdata
+package main
 
+// Settings is the application settings.
 type Settings struct {
 	// Database is the database settings
 	Database Database `envPrefix:"DB_"`
+
+	// Server is the server settings
+	Server ServerConfig `envPrefix:"SERVER_"`
 
 	// Debug is the debug flag
 	Debug bool `env:"DEBUG"`
 }
 
+// Database is the database settings.
 type Database struct {
 	// Port is the port to connect to
 	Port Int `env:"PORT,required"`
+	// Host is the host to connect to
+	Host string `env:"HOST,notEmpty" envDefault:"localhost"`
+	// User is the user to connect as
+	User string `env:"USER"`
+	// Password is the password to use
+	Password string `env:"PASSWORD"`
+	// DisableTLS is the flag to disable TLS
+	DisableTLS bool `env:"DISABLE_TLS"`
+}
+
+// ServerConfig is the server settings.
+type ServerConfig struct {
+	// Port is the port to listen on
+	Port Int `env:"PORT,required"`
+
+	// Host is the host to listen on
+	Host string `env:"HOST,notEmpty" envDefault:"localhost"`
+
+	// Timeout is the timeout settings
+	Timeout TimeoutConfig `envPrefix:"TIMEOUT_"`
+}
+
+// TimeoutConfig is the timeout settings.
+type TimeoutConfig struct {
+	// Read is the read timeout
+	Read Int `env:"READ" envDefault:"30"`
+	// Write is the write timeout
+	Write Int `env:"WRITE" envDefault:"30"`
 }

--- a/types.go
+++ b/types.go
@@ -8,6 +8,10 @@ type EnvDocItem struct {
 	Doc string
 	// Opts is a set of options for environment variable parsing.
 	Opts EnvVarOptions
+	// Children is a list of child environment variables.
+	Children []EnvDocItem
+
+	debugName string // item name for debug logs.
 }
 
 type EnvScope struct {


### PR DESCRIPTION
Render nested structures annotated with `envPrefix` as sublists of origin field, using documentation from the origin field as a text for this sublist.

Ref: #2