### PR TITLE
fix: parse anonymous structure fields

### DIFF
--- a/_examples/complex-nostyle.html
+++ b/_examples/complex-nostyle.html
@@ -23,6 +23,12 @@ It is trying to cover all the possible cases.</p>
     <li><code>HOSTS</code> (separated by "<code>:</code>", <strong>required</strong>) - Hosts is a list of hosts.</li>
     <li><code>WORDS</code> (comma-separated, from-file, default: <code>one,two,three</code>) - Words is just a list of words.</li>
     <li><code>COMMENT</code> (<strong>required</strong>, default: <code>This is a comment.</code>) - Just a comment.</li>
+    <li>Anon is an anonymous structure.
+    <ul>
+    <li><code>ANON_USER</code> (<strong>required</strong>) - User is a user name.</li>
+    <li><code>ANON_PASS</code> (<strong>required</strong>) - Pass is a password.</li>
+    </ul>
+  </li>
   </ul>
 
   <h2>NextConfig</h2>

--- a/_examples/complex.go
+++ b/_examples/complex.go
@@ -27,6 +27,14 @@ type ComplexConfig struct {
 	Words []string `env:"WORDS,file" envDefault:"one,two,three"`
 
 	Comment string `env:"COMMENT,required" envDefault:"This is a comment."` // Just a comment.
+
+	// Anon is an anonymous structure.
+	Anon struct {
+		// User is a user name.
+		User string `env:"USER,required"`
+		// Pass is a password.
+		Pass string `env:"PASS,required"`
+	} `envPrefix:"ANON_"`
 }
 
 type NextConfig struct { // NextConfig is a configuration structure.

--- a/_examples/complex.html
+++ b/_examples/complex.html
@@ -89,6 +89,12 @@ It is trying to cover all the possible cases.</p>
     <li><code>HOSTS</code> (separated by "<code>:</code>", <strong>required</strong>) - Hosts is a list of hosts.</li>
     <li><code>WORDS</code> (comma-separated, from-file, default: <code>one,two,three</code>) - Words is just a list of words.</li>
     <li><code>COMMENT</code> (<strong>required</strong>, default: <code>This is a comment.</code>) - Just a comment.</li>
+    <li>Anon is an anonymous structure.
+    <ul>
+    <li><code>ANON_USER</code> (<strong>required</strong>) - User is a user name.</li>
+    <li><code>ANON_PASS</code> (<strong>required</strong>) - Pass is a password.</li>
+    </ul>
+  </li>
   </ul>
 
   <h2>NextConfig</h2>

--- a/_examples/complex.md
+++ b/_examples/complex.md
@@ -14,6 +14,9 @@ It is trying to cover all the possible cases.
  - `HOSTS` (separated by `:`, **required**) - Hosts is a list of hosts.
  - `WORDS` (comma-separated, from-file, default: `one,two,three`) - Words is just a list of words.
  - `COMMENT` (**required**, default: `This is a comment.`) - Just a comment.
+ - Anon is an anonymous structure.
+   - `ANON_USER` (**required**) - User is a user name.
+   - `ANON_PASS` (**required**) - Pass is a password.
 
 ## NextConfig
 

--- a/_examples/complex.txt
+++ b/_examples/complex.txt
@@ -14,6 +14,9 @@ It is trying to cover all the possible cases.
  * `HOSTS` (separated by `:`, required) - Hosts is a list of hosts.
  * `WORDS` (comma-separated, from-file, default: `one,two,three`) - Words is just a list of words.
  * `COMMENT` (required, default: `This is a comment.`) - Just a comment.
+ * Anon is an anonymous structure.
+   * `ANON_USER` (required) - User is a user name.
+   * `ANON_PASS` (required) - Pass is a password.
 
 ## NextConfig
 

--- a/_examples/x_complex.md
+++ b/_examples/x_complex.md
@@ -14,6 +14,9 @@ It is trying to cover all the possible cases.
  - `X_HOSTS` (separated by `:`, **required**) - Hosts is a list of hosts.
  - `X_WORDS` (comma-separated, from-file, default: `one,two,three`) - Words is just a list of words.
  - `X_COMMENT` (**required**, default: `This is a comment.`) - Just a comment.
+ - `X_` - Anon is an anonymous structure.
+   - `X_ANON_USER` (**required**) - User is a user name.
+   - `X_ANON_PASS` (**required**) - Pass is a password.
 
 ## NextConfig
 

--- a/inspector_test.go
+++ b/inspector_test.go
@@ -277,52 +277,6 @@ func TestInspector(t *testing.T) {
 			},
 		},
 		{
-			/*
-				type Settings struct {
-					// Database is the database settings
-					Database Database `envPrefix:"DB_"`
-
-					// Server is the server settings
-					Server ServerConfig `envPrefix:"SERVER_"`
-
-					// Debug is the debug flag
-					Debug bool `env:"DEBUG"`
-				}
-
-				// Database is the database settings.
-				type Database struct {
-					// Port is the port to connect to
-					Port Int `env:"PORT,required"`
-					// Host is the host to connect to
-					Host string `env:"HOST,nonempty" envDefault:"localhost"`
-					// User is the user to connect as
-					User string `env:"USER"`
-					// Password is the password to use
-					Password string `env:"PASSWORD"`
-					// DisableTLS is the flag to disable TLS
-					DisableTLS bool `env:"DISABLE_TLS"`
-				}
-
-				// ServerConfig is the server settings.
-				type ServerConfig struct {
-					// Port is the port to listen on
-					Port Int `env:"PORT,required"`
-
-					// Host is the host to listen on
-					Host string `env:"HOST,nonempty" envDefault:"localhost"`
-
-					// Timeout is the timeout settings
-					Timeout TimeoutConfig `envPrefix:"TIMEOUT_"`
-				}
-
-				// TimeoutConfig is the timeout settings.
-				type TimeoutConfig struct {
-					// Read is the read timeout
-					Read Int `env:"READ" envDefault:"30"`
-					// Write is the write timeout
-					Write Int `env:"WRITE" envDefault:"30"`
-				}
-			*/
 			name:     "envprefix.go",
 			typeName: "Settings",
 			expect: []EnvDocItem{
@@ -389,6 +343,22 @@ func TestInspector(t *testing.T) {
 				{
 					Name: "DEBUG",
 					Doc:  "Debug is the debug flag",
+				},
+			},
+		},
+		{
+			name:     "anonymous.go",
+			typeName: "Config",
+			expect: []EnvDocItem{
+				{
+					Doc: "Repo is the configuration for the repository.",
+					Children: []EnvDocItem{
+						{
+							Name: "REPO_CONN",
+							Doc:  "Conn is the connection string for the repository.",
+							Opts: EnvVarOptions{Required: true, NonEmpty: true},
+						},
+					},
 				},
 			},
 		},

--- a/testdata/anonymous.go
+++ b/testdata/anonymous.go
@@ -1,0 +1,10 @@
+package main
+
+// Config is the configuration for the application.
+type Config struct {
+	// Repo is the configuration for the repository.
+	Repo struct {
+		// Conn is the connection string for the repository.
+		Conn string `env:"CONN,notEmpty"`
+	} `envPrefix:"REPO_"`
+}

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io"
+	"math/rand"
 	"strings"
 	"unicode"
 )
@@ -28,4 +29,14 @@ func camelToSnake(s string) string {
 	}
 
 	return result.String()
+}
+
+func fastRandString(n int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	seed := rand.Intn(len(letters)*len(letters)) + 1
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letters[(seed+i)%len(letters)]
+	}
+	return string(b)
 }


### PR DESCRIPTION
If the field is `envPrefix`-ed anonymous structure, then inspector handles this structure with random-generated type name and use field doc and comments as struct attributes.

Fix: #5