### PR TITLE
fix: don't panic on empty field doc

### DIFF
--- a/inspector.go
+++ b/inspector.go
@@ -235,11 +235,12 @@ func (i *inspector) parseField(f *ast.Field) (out []envField) {
 			item.typeRef = fieldType.Name
 		case *ast.StructType:
 			nameGen := fastRandString(16)
-			i.getStruct(&ast.TypeSpec{
+			typeSpec := &ast.TypeSpec{
 				Name: &ast.Ident{Name: nameGen},
 				Type: fieldType,
-				Doc:  &ast.CommentGroup{List: f.Doc.List},
-			})
+				Doc:  f.Doc,
+			}
+			i.getStruct(typeSpec)
 			item.typeRef = nameGen
 			posRange := [2]token.Pos{fieldType.Pos(), fieldType.End()}
 			i.anonymousStructs[posRange] = anonymousStruct{

--- a/inspector_test.go
+++ b/inspector_test.go
@@ -362,6 +362,20 @@ func TestInspector(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "nodocs.go",
+			typeName: "Config",
+			expect: []EnvDocItem{
+				{
+					Children: []EnvDocItem{
+						{
+							Name: "REPO_CONN",
+							Opts: EnvVarOptions{Required: true, NonEmpty: true},
+						},
+					},
+				},
+			},
+		},
 	} {
 		scopes := c.expectScopes
 		if scopes == nil {

--- a/testdata/nodocs.go
+++ b/testdata/nodocs.go
@@ -1,0 +1,7 @@
+package main
+
+type Config struct {
+	Repo struct {
+		Conn string `env:"CONN,notEmpty"`
+	} `envPrefix:"REPO_"`
+}


### PR DESCRIPTION
Fix panic when parsing an empty doc string in anonymous structure field.

Ref: #2