### PR TITLE
fix: skip function declarations for ast parser

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -166,6 +166,8 @@ func (v *astVisitor) Visit(n ast.Node) ast.Visitor {
 			fieldNode.typeName = expr.Name
 		}
 		return v.push(fieldNode, true)
+	case *ast.FuncDecl:
+		return nil
 	}
 	return v
 }

--- a/inspector_test.go
+++ b/inspector_test.go
@@ -368,6 +368,17 @@ func TestInspector(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "funcs.go",
+			all:  true,
+			expect: []*EnvDocItem{
+				{
+					Name: "SOME_VALUE",
+					Opts: EnvVarOptions{Default: "somevalue"},
+					Doc:  "this is some value",
+				},
+			},
+		},
 	} {
 		scopes := c.expectScopes
 		if scopes == nil {

--- a/testdata/funcs.go
+++ b/testdata/funcs.go
@@ -1,0 +1,18 @@
+package testdata
+
+// Test case for #21 where the envdoc panics if target type function presents.
+
+//go:generate envdoc -output test.md --all
+type aconfig struct {
+	// this is some value
+	somevalue string `env:"SOME_VALUE" envDefault:"somevalue"`
+}
+
+// when this function is present, go generate panics with "expected type node root child, got nodeField ()".
+func someFuncThatTakesInput(configs ...interface{}) {
+	// this is some comment
+}
+
+func (a *aconfig) someFuncThatTakesInput(configs ...interface{}) {
+	// this is some comment
+}


### PR DESCRIPTION
Skip `FuncDect` because funcs may declare fields inside it, where fields could be handled as a part of current type.

Fix: #21