### PR TITLE
fix: un-escape glob patterns

### DIFF
--- a/_examples/all_files.go
+++ b/_examples/all_files.go
@@ -1,2 +1,2 @@
-//go:generate go run ../ -output all.md -dir . -files * -types *
+//go:generate go run ../ -debug -output all.md -dir . -files * -types='*'
 package main

--- a/_examples/complex-fields.html
+++ b/_examples/complex-fields.html
@@ -76,6 +76,17 @@ p {
       <article>
         <h1>Environment Variables</h1>
 
+  <h2>FieldNames</h2>
+<p>FieldNames uses field names as env names.</p>
+  <ul>
+    <li><code>FOO</code> - Foo is a single field.</li>
+    <li><code>BAR</code> - Bar and Baz are two fields.</li>
+    <li><code>BAZ</code> - Bar and Baz are two fields.</li>
+    <li><code>QUUX</code> - Quux is a field with a tag.</li>
+    <li><code>FOO_BAR</code> (default: <code>quuux</code>) - FooBar is a field with a default value.</li>
+    <li>Required is a required field.</li>
+  </ul>
+
       </article>
     </section>
   </body>

--- a/config.go
+++ b/config.go
@@ -127,6 +127,11 @@ func (c *Config) parseEnv() error {
 	return nil
 }
 
+func (c *Config) normalize() {
+	c.TypeGlob = unescapeGlob(c.TypeGlob)
+	c.FileGlob = unescapeGlob(c.FileGlob)
+}
+
 func (c *Config) setDefaults() {
 	if c.FileGlob == "" {
 		c.FileGlob = c.ExecFile
@@ -172,5 +177,6 @@ func (c *Config) Load() error {
 		return fmt.Errorf("parse env: %w", err)
 	}
 	c.setDefaults()
+	c.normalize()
 	return nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+func TestConfig(t *testing.T) {
+	t.Run("parse flags", func(t *testing.T) {
+		var c Config
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		os.Args = []string{
+			"test",
+			"-types", "foo,bar",
+			"-files", "*",
+			"-output", "out.txt",
+			"-format", "plaintext",
+			"-env-prefix", "FOO",
+			"-no-styles",
+			"-field-names",
+			"-debug",
+		}
+		if err := c.parseFlags(fs); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if c.TypeGlob != "foo,bar" {
+			t.Errorf("unexpected TypeGlob: %q", c.TypeGlob)
+		}
+		if c.FileGlob != "*" {
+			t.Errorf("unexpected FileGlob: %q", c.FileGlob)
+		}
+		if c.OutFile != "out.txt" {
+			t.Errorf("unexpected OutFile: %q", c.OutFile)
+		}
+		if c.OutFormat != "plaintext" {
+			t.Errorf("unexpected OutFormat: %q", c.OutFormat)
+		}
+		if c.EnvPrefix != "FOO" {
+			t.Errorf("unexpected EnvPrefix: %q", c.EnvPrefix)
+		}
+		if !c.NoStyles {
+			t.Error("unexpected NoStyles: false")
+		}
+		if !c.FieldNames {
+			t.Error("unexpected FieldNames: false")
+		}
+		if !c.Debug {
+			t.Error("unexpected Debug: false")
+		}
+	})
+	t.Run("normalize", func(t *testing.T) {
+		var c Config
+		c.TypeGlob = `"foo"`
+		c.FileGlob = `"*"`
+		c.normalize()
+		if c.TypeGlob != "foo" {
+			t.Errorf("unexpected TypeGlob: %q", c.TypeGlob)
+		}
+		if c.FileGlob != "*" {
+			t.Errorf("unexpected FileGlob: %q", c.FileGlob)
+		}
+	})
+}

--- a/utils.go
+++ b/utils.go
@@ -52,3 +52,12 @@ func camelToSnake(s string) string {
 
 	return result.String()
 }
+
+// un-escape -types and -files globs: '*' -> *, "foo" -> foo
+// if first and last characters are quotes, remove them.
+func unescapeGlob(s string) string {
+	if len(s) >= 2 && ((s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'')) {
+		return s[1 : len(s)-1]
+	}
+	return s
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -118,3 +118,25 @@ func TestCamelToSnake(t *testing.T) {
 		}
 	}
 }
+
+func TestUnescapeGlob(t *testing.T) {
+	tests := map[string]string{
+		`"foo"`: `foo`,
+		`"foo`:  `"foo`,
+		`foo"`:  `foo"`,
+		`foo`:   `foo`,
+		`'foo'`: `foo`,
+		`'foo`:  `'foo`,
+		`foo'`:  `foo'`,
+		`*`:     `*`,
+		`*foo*`: `*foo*`,
+		`'*'`:   `*`,
+		``:      ``,
+	}
+
+	for input, expected := range tests {
+		if got := unescapeGlob(input); got != expected {
+			t.Errorf("unexpected result for %q: got %q, want %q", input, got, expected)
+		}
+	}
+}


### PR DESCRIPTION
Remove single and double quotes from the beginning and end of glob pattern.

Fix: #26