### PR TITLE
Feat: cleanenv support, markdown-table template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /.gitstrap.yml
 /envdoc
+/.idea
 coverage.out
 test.cover
+*/**/go.work*

--- a/README.md
+++ b/README.md
@@ -41,21 +41,28 @@ type Config struct {
 ## Usage
 
 ```go
-//go:generate envdoc -output <output_file_name>
+//go:generate envdoc -output <output_file_name> dir_1 dir_n
 ```
 
  * `-dir` (path string, *optional*) - Specify the directory to search for files. Default is the file dir with `go:generate` command.
  * `-files` (glob string, *optional*) - File glob pattern to specify file names to process. Default is the single file with `go:generate`.
  * `-types` (glob string, *optional*) - Type glob pattern for type names to process. If not specified, the next type after `go:generate` is used.
  * `-output` (path string, **required**) - Output file name for generated documentation.
- * `-format` (`enum(markdown, plaintext, html, dotenv)` string, *optional*) - Output format for documentation.  Default is `markdown`.
+ * `-format` (`enum(markdown, markdown-table, plaintext, html, dotenv)` string, *optional*) - Output format for documentation.  Default is `markdown`.
  * `-no-styles` (`bool`, *optional*) - If true, CSS styles will not be included for `html` format.
  * `-env-prefix` (`string`, *optional*) - Sets additional global prefix for all environment variables.
  * `-tag-name` (string, *optional*, default: `env`) - Use custom tag name instead of `env`.
  * `-tag-default` (string, *optional*, default: `envDefault`) - Use "default" tag name instead of `envDefault`.
+ * `-tag-prefix` (string, *optional*, default: `envPrefix`) - Use "prefix" tag name instead of `envPrefix`.
+ * `-tag-separator` (string, *optional*, default: `envSeparator`) - Use "separator" tag name instead of `envSeparator`.
+ * `-tag-description` (string, *optional*) - Use "description" tag name instead of doc comments.
+ * `-tag-required` (string, *optional*) - Use "required" tag name.
  * `-required-if-no-def` (bool, *optional*, default: `false`) - Set attributes as required if no default value is set.
  * `-field-names` (`bool`, *optional*) - Use field names as env names if `env:` tag is not specified.
  * `-debug` (`bool`, *optional*) - Enable debug output.
+
+Positional args:
+* `dir_n` (path string list, *optional*) - Specify the directories to search for files. Default is the file dir with `go:generate` command.
 
 These params are deprecated and will be removed in the next major release:
  * `-type` - Specify one type to process.
@@ -98,6 +105,7 @@ This tool is compatible with
 - full compatibility: [caarlos0/env](https://github.com/caarlos0/env)
 - partial compatibility: [sethvargo/go-envconfig](https://github.com/sethvargo/go-envconfig)
 - partial compatibility: [joeshaw/envdecode](https://github.com/joeshaw/envdecode)
+- partial compatibility: [ilyakaznacheev/cleanenv](https://github.com/ilyakaznacheev/cleanenv)
 
 *Let me know about any new lib to check compatibility.*
 

--- a/_examples/multi-project/lib/go.mod
+++ b/_examples/multi-project/lib/go.mod
@@ -1,0 +1,3 @@
+module lib
+
+go 1.23

--- a/_examples/multi-project/lib/logging/cfg.go
+++ b/_examples/multi-project/lib/logging/cfg.go
@@ -1,0 +1,8 @@
+package logging
+
+type Config struct {
+	// Level of the logging.
+	Level string `env:"LEVEL" envDefault:"info"`
+	// Format of the logging.
+	Format string `env:"FORMAT" envDefault:"json"`
+}

--- a/_examples/multi-project/project/config/cfg.go
+++ b/_examples/multi-project/project/config/cfg.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"lib/logging"
+	"project/server"
+)
+
+//go:generate go run ../../../../ -files ./config/cfg.go -types * -output ../doc.md -format markdown-table ../ ../../lib/
+type Config struct {
+	// AppName is the name of the application.
+	AppName string `env:"APP_NAME" envDefault:"myapp"`
+
+	// Server config.
+	Server server.Config `envPrefix:"SERVER_"`
+
+	// Logging config.
+	Log logging.Config `envPrefix:"LOG_"`
+}

--- a/_examples/multi-project/project/doc.md
+++ b/_examples/multi-project/project/doc.md
@@ -1,0 +1,14 @@
+# Environment Variables
+
+## Config
+
+| env variable | type | description | options |
+|--------------|------|-------------|---------|
+| APP_NAME | `string` | AppName is the name of the application. | (default: `myapp`) |
+| SERVER_HOST | `string` | Host of the server. | (**required**) |
+| SERVER_PORT | `string` | Port of the server. | (**required**) |
+| SERVER_TIMEOUT_READ | `string` | ReadTimeout of the server. | (**required**) |
+| SERVER_TIMEOUT_WRITE | `string` | WriteTimeout of the server. | (**required**) |
+| LOG_LEVEL | `string` | Level of the logging. | (default: `info`) |
+| LOG_FORMAT | `string` | Format of the logging. | (default: `json`) |
+

--- a/_examples/multi-project/project/go.mod
+++ b/_examples/multi-project/project/go.mod
@@ -1,0 +1,3 @@
+module project
+
+go 1.23

--- a/_examples/multi-project/project/server/cfg.go
+++ b/_examples/multi-project/project/server/cfg.go
@@ -1,0 +1,10 @@
+package server
+
+type Config struct {
+	// Host of the server.
+	Host string `env:"HOST,required"`
+	// Port of the server.
+	Port string `env:"PORT,required"`
+	// Timeout of the server.
+	Timeout TimeoutConfig `envPrefix:"TIMEOUT_"`
+}

--- a/_examples/multi-project/project/server/timeout_cfg.go
+++ b/_examples/multi-project/project/server/timeout_cfg.go
@@ -1,0 +1,9 @@
+package server
+
+// TimeoutConfig holds the configuration for the timeouts of the server.
+type TimeoutConfig struct {
+	// ReadTimeout of the server.
+	ReadTimeout string `env:"READ,required"`
+	// WriteTimeout of the server.
+	WriteTimeout string `env:"WRITE,required"`
+}

--- a/_examples/project/config/cfg.go
+++ b/_examples/project/config/cfg.go
@@ -5,7 +5,7 @@ import (
 	"example.com/server"
 )
 
-//go:generate go run ../../../ -dir ../ -files ./config/cfg.go -types * -output ../config.md -format markdown
+//go:generate go run ../../../ -dir ../ -files ./config/cfg.go -types * -output ../doc.md -format markdown
 type Config struct {
 	// AppName is the name of the application.
 	AppName string `env:"APP_NAME" envDefault:"myapp"`

--- a/_examples/project/doc.md
+++ b/_examples/project/doc.md
@@ -1,0 +1,19 @@
+# Environment Variables
+
+## Config
+
+ - `APP_NAME` (default: `myapp`) - AppName is the name of the application.
+ - `SERVER_HOST` (**required**) - Host of the server.
+ - `SERVER_PORT` (**required**) - Port of the server.
+ - `SERVER_TIMEOUT_READ` (**required**) - ReadTimeout of the server.
+ - `SERVER_TIMEOUT_WRITE` (**required**) - WriteTimeout of the server.
+ - `DB_HOST` (**required**) - Host of the database.
+ - `DB_PORT` (**required**) - Port of the database.
+ - `DB_USER` (default: `user`) - User of the database.
+ - `DB_PASSWORD` - Password of the database.
+ - `DB_MODE` (default: `disable`) - SslMode of the database.
+ - `DB_CERT` - SslCert of the database.
+ - `DB_KEY` - SslKey of the database.
+ - `LOG_LEVEL` (default: `info`) - Level of the logging.
+ - `LOG_FORMAT` (default: `json`) - Format of the logging.
+

--- a/_examples/simple/config.go
+++ b/_examples/simple/config.go
@@ -6,6 +6,7 @@ package main
 //
 //go:generate go run ../../ -output doc.txt -format plaintext
 //go:generate go run ../../ -output doc.md -format markdown
+//go:generate go run ../../ -output doc-table.md -format markdown-table
 //go:generate go run ../../ -output doc.html -format html
 //go:generate go run ../../ -output doc.env -format dotenv
 type Config struct {

--- a/_examples/simple/doc-table.md
+++ b/_examples/simple/doc-table.md
@@ -1,0 +1,15 @@
+# Environment Variables
+
+## Config
+
+Config is an example configuration structure.
+It is used to generate documentation for the configuration
+using the commands below.
+
+| env variable | type | description | options |
+|--------------|------|-------------|---------|
+| HOST | `[]string` | Hosts name of hosts to listen on. | (separated by `;`, **required**) |
+| PORT | `int` | Port to listen on. | (**required**, non-empty) |
+| DEBUG | `bool` | Debug mode enabled. | (default: `false`) |
+| PREFIX | `string` | Prefix for something. |  |
+

--- a/ast/decoder_test.go
+++ b/ast/decoder_test.go
@@ -14,7 +14,7 @@ func TestFieldSpecDecoder(t *testing.T) {
 			Tag:     `env:"FOO,required"`,
 			TypeRef: FieldTypeRef{Name: "string", Kind: FieldTypeIdent},
 		}
-		d := NewFieldSpecDecoder("", "env", "", false, false)
+		d := NewFieldSpecDecoder("", "env", "", "envPrefix", "envSeparator", "", "", false, false)
 		res, prefix := d.Decode(fs)
 		assertEqFieldInfo(t, FieldInfo{
 			Names:    []string{"FOO"},
@@ -28,7 +28,7 @@ func TestFieldSpecDecoder(t *testing.T) {
 			Doc:     "foo doc",
 			TypeRef: FieldTypeRef{Name: "string", Kind: FieldTypeIdent},
 		}
-		d := NewFieldSpecDecoder("", "env", "", false, true)
+		d := NewFieldSpecDecoder("", "env", "", "envPrefix", "envSeparator", "", "", false, true)
 		res, prefix := d.Decode(fs)
 		assertEqFieldInfo(t, FieldInfo{
 			Names: []string{"FOO", "BAR"},
@@ -42,7 +42,7 @@ func TestFieldSpecDecoder(t *testing.T) {
 			Tag:     `env:"FOO" default:"bar"`,
 			TypeRef: FieldTypeRef{Name: "string", Kind: FieldTypeIdent},
 		}
-		d := NewFieldSpecDecoder("", "env", "default", false, false)
+		d := NewFieldSpecDecoder("", "env", "default", "envPrefix", "envSeparator", "", "", false, false)
 		res, prefix := d.Decode(fs)
 		assertEqFieldInfo(t, FieldInfo{
 			Names:   []string{"FOO"},
@@ -57,7 +57,7 @@ func TestFieldSpecDecoder(t *testing.T) {
 			Tag:     `env:"FOO"`,
 			TypeRef: FieldTypeRef{Name: "string", Kind: FieldTypeIdent},
 		}
-		d := NewFieldSpecDecoder("PREFIX_", "env", "", false, false)
+		d := NewFieldSpecDecoder("PREFIX_", "env", "", "envPrefix", "envSeparator", "", "", false, false)
 		res, prefix := d.Decode(fs)
 		assertEqFieldInfo(t, FieldInfo{
 			Names: []string{"PREFIX_FOO"},
@@ -71,7 +71,7 @@ func TestFieldSpecDecoder(t *testing.T) {
 			Tag:     `env:"FOO"`,
 			TypeRef: FieldTypeRef{Name: "string", Kind: FieldTypeArray},
 		}
-		d := NewFieldSpecDecoder("", "env", "", false, false)
+		d := NewFieldSpecDecoder("", "env", "", "envPrefix", "envSeparator", "", "", false, false)
 		res, prefix := d.Decode(fs)
 		assertEqFieldInfo(t, FieldInfo{
 			Names:     []string{"FOO"},
@@ -86,7 +86,7 @@ func TestFieldSpecDecoder(t *testing.T) {
 			Tag:     `env:"FOO" envSeparator:";"`,
 			TypeRef: FieldTypeRef{Name: "string", Kind: FieldTypeArray},
 		}
-		d := NewFieldSpecDecoder("", "env", "", false, false)
+		d := NewFieldSpecDecoder("", "env", "", "envPrefix", "envSeparator", "", "", false, false)
 		res, prefix := d.Decode(fs)
 		assertEqFieldInfo(t, FieldInfo{
 			Names:     []string{"FOO"},
@@ -101,7 +101,7 @@ func TestFieldSpecDecoder(t *testing.T) {
 			Tag:     `env:"FOO"`,
 			TypeRef: FieldTypeRef{Name: "string", Kind: FieldTypeIdent},
 		}
-		d := NewFieldSpecDecoder("", "env", "", true, false)
+		d := NewFieldSpecDecoder("", "env", "", "envPrefix", "envSeparator", "", "", true, false)
 		res, prefix := d.Decode(fs)
 		assertEqFieldInfo(t, FieldInfo{
 			Names:    []string{"FOO"},
@@ -116,7 +116,7 @@ func TestFieldSpecDecoder(t *testing.T) {
 			Tag:     `env:"FOO,expand"`,
 			TypeRef: FieldTypeRef{Name: "string", Kind: FieldTypeIdent},
 		}
-		d := NewFieldSpecDecoder("", "env", "", false, false)
+		d := NewFieldSpecDecoder("", "env", "", "envPrefix", "envSeparator", "", "", false, false)
 		res, prefix := d.Decode(fs)
 		assertEqFieldInfo(t, FieldInfo{
 			Names:  []string{"FOO"},
@@ -131,7 +131,7 @@ func TestFieldSpecDecoder(t *testing.T) {
 			Tag:     `env:"FOO,notEmpty"`,
 			TypeRef: FieldTypeRef{Name: "string", Kind: FieldTypeIdent},
 		}
-		d := NewFieldSpecDecoder("", "env", "", false, false)
+		d := NewFieldSpecDecoder("", "env", "", "envPrefix", "envSeparator", "", "", false, false)
 		res, prefix := d.Decode(fs)
 		assertEqFieldInfo(t, FieldInfo{
 			Names:    []string{"FOO"},
@@ -147,7 +147,7 @@ func TestFieldSpecDecoder(t *testing.T) {
 			Tag:     `env:"FOO,file"`,
 			TypeRef: FieldTypeRef{Name: "string", Kind: FieldTypeIdent},
 		}
-		d := NewFieldSpecDecoder("", "env", "", false, false)
+		d := NewFieldSpecDecoder("", "env", "", "envPrefix", "envSeparator", "", "", false, false)
 		res, prefix := d.Decode(fs)
 		assertEqFieldInfo(t, FieldInfo{
 			Names:    []string{"FOO"},
@@ -162,7 +162,7 @@ func TestFieldSpecDecoder(t *testing.T) {
 			Tag:     `env:"FOO" envPrefix:"BAR_"`,
 			TypeRef: FieldTypeRef{Name: "string", Kind: FieldTypeIdent},
 		}
-		d := NewFieldSpecDecoder("X_", "env", "", false, false)
+		d := NewFieldSpecDecoder("X_", "env", "", "envPrefix", "envSeparator", "", "", false, false)
 		_, prefix := d.Decode(fs)
 		testutils.AssertError(t, prefix == "X_BAR_", "unexpected prefix: %s", prefix)
 	})

--- a/config.go
+++ b/config.go
@@ -16,6 +16,8 @@ import (
 type Config struct {
 	// Dir to search for files
 	Dir string
+	// Dirs to search for files
+	Dirs []string
 	// FileGlob to filter by file name
 	FileGlob string
 	// TypeGlob to filter by type name
@@ -35,7 +37,15 @@ type Config struct {
 	TagName string
 	// TagDefault sets default env tag name, `envDefault` by default.
 	TagDefault string
-	// TagRequiredIfNoDef sets attributes as required if no default value is set.
+	// TagPrefix sets custom tag prefix, `envPrefix` by default.
+	TagPrefix string
+	// TagSeparator sets custom tag prefix, `envSeparator` by default.
+	TagSeparator string
+	// TagDescription sets doc tag.
+	TagDescription string
+	// TagRequired sets required tag.
+	TagRequired string
+	// RequiredIfNoDef sets attributes as required if no default value is set.
 	RequiredIfNoDef bool
 
 	// ExecLine is the line of go:generate command
@@ -64,6 +74,10 @@ func (c *Config) parseFlags(f *flag.FlagSet) error {
 	// customization
 	f.StringVar(&c.TagName, "tag-name", "env", "Custom tag name")
 	f.StringVar(&c.TagDefault, "tag-default", "envDefault", "Default tag name")
+	f.StringVar(&c.TagPrefix, "tag-prefix", "envPrefix", "Prefix tag name")
+	f.StringVar(&c.TagSeparator, "tag-separator", "envSeparator", "Separator tag name")
+	f.StringVar(&c.TagDescription, "tag-description", "", "Description tag name")
+	f.StringVar(&c.TagRequired, "tag-required", "", "Required tag name")
 	f.BoolVar(&c.RequiredIfNoDef, "required-if-no-def", false, "Set attributes as required if no default value is set")
 	// deprecated flags
 	var (
@@ -77,6 +91,9 @@ func (c *Config) parseFlags(f *flag.FlagSet) error {
 	if err := f.Parse(os.Args[1:]); err != nil {
 		return fmt.Errorf("parse flags: %w", err)
 	}
+
+	// additional dirs
+	c.Dirs = f.Args()
 
 	// deprecated flags `all`, `type` and new flag `types` can't be used together
 	if all && typeName != "" {
@@ -142,14 +159,17 @@ func (c *Config) setDefaults() {
 	if c.FileGlob == "" {
 		c.FileGlob = c.ExecFile
 	}
+
 	if c.Dir == "" {
 		c.Dir = "."
 	}
+
+	c.Dirs = append(c.Dirs, c.Dir)
 }
 
 func (c *Config) fprint(out io.Writer) {
 	fmt.Fprintln(out, "Config:")
-	fmt.Fprintf(out, "  Dir: %q\n", c.Dir)
+	fmt.Fprintf(out, "  Dirs: %q\n", c.Dirs)
 	if c.FileGlob != "" {
 		fmt.Fprintf(out, "  FileGlob: %q\n", c.FileGlob)
 	}

--- a/converter.go
+++ b/converter.go
@@ -18,6 +18,10 @@ type ConverterOpts struct {
 	EnvPrefix       string
 	TagName         string
 	TagDefault      string
+	TagPrefix       string
+	TagSeparator    string
+	TagDescription  string
+	TagRequired     string
 	RequiredIfNoDef bool
 	UseFieldNames   bool
 }
@@ -83,7 +87,17 @@ func (c *Converter) DocItemsFromFields(res Resolver, prefix string, fields []*as
 }
 
 func (c *Converter) DocItemsFromField(resolver Resolver, prefix string, f *ast.FieldSpec) []*types.EnvDocItem {
-	dec := ast.NewFieldSpecDecoder(prefix, c.opts.TagName, c.opts.TagDefault, c.opts.RequiredIfNoDef, c.opts.UseFieldNames)
+	dec := ast.NewFieldSpecDecoder(
+		prefix,
+		c.opts.TagName,
+		c.opts.TagDefault,
+		c.opts.TagPrefix,
+		c.opts.TagSeparator,
+		c.opts.TagDescription,
+		c.opts.TagRequired,
+		c.opts.RequiredIfNoDef,
+		c.opts.UseFieldNames,
+	)
 	info, newPrefix := dec.Decode(f)
 	if newPrefix != "" {
 		prefix = newPrefix
@@ -115,18 +129,21 @@ func (c *Converter) DocItemsFromField(resolver Resolver, prefix string, f *ast.F
 
 	res := make([]*types.EnvDocItem, len(info.Names), len(info.Names)+1)
 	opts := types.EnvVarOptions{
-		Required:  info.Required,
-		Expand:    info.Expand,
-		NonEmpty:  info.NonEmpty,
-		FromFile:  info.FromFile,
-		Default:   info.Default,
-		Separator: info.Separator,
+		Required:    info.Required,
+		Expand:      info.Expand,
+		NonEmpty:    info.NonEmpty,
+		FromFile:    info.FromFile,
+		Default:     info.Default,
+		Separator:   info.Separator,
+		Description: info.Description,
 	}
+
 	for i, name := range info.Names {
 		res[i] = &types.EnvDocItem{
 			Name:     name,
 			Doc:      f.Doc,
 			Opts:     opts,
+			Type:     f.TypeRef.String(),
 			Children: children,
 		}
 		debug.Logf("\t# CONV: docItem %q (%d childrens)\n", name, len(children))

--- a/converter_test.go
+++ b/converter_test.go
@@ -10,8 +10,10 @@ import (
 )
 
 var opts = ConverterOpts{
-	TagName:    "env",
-	TagDefault: "envDefault",
+	TagName:      "env",
+	TagDefault:   "envDefault",
+	TagPrefix:    "envPrefix",
+	TagSeparator: "envSeparator",
 }
 
 func TestConvertDocItems(t *testing.T) {

--- a/generator.go
+++ b/generator.go
@@ -28,10 +28,14 @@ func NewGenerator(parser *ast.Parser, converter *Converter, renderer Renderer) *
 	}
 }
 
-func (g *Generator) Generate(dir string, out io.Writer) error {
-	files, err := g.parser.Parse(dir)
-	if err != nil {
-		return fmt.Errorf("parse dir: %w", err)
+func (g *Generator) Generate(dirs []string, out io.Writer) error {
+	var files []*ast.FileSpec
+	for _, dir := range dirs {
+		fileSpec, err := g.parser.Parse(dir)
+		if err != nil {
+			return fmt.Errorf("parse dir[%s]: %w", dir, err)
+		}
+		files = append(files, fileSpec...)
 	}
 
 	res := resolver.ResolveAllTypes(files)

--- a/generator_test.go
+++ b/generator_test.go
@@ -10,10 +10,11 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/tools/txtar"
+
 	"github.com/g4s8/envdoc/ast"
 	"github.com/g4s8/envdoc/render"
 	"github.com/g4s8/envdoc/types"
-	"golang.org/x/tools/txtar"
 )
 
 func TestGenerator(t *testing.T) {
@@ -46,6 +47,8 @@ func TestGenerator(t *testing.T) {
 				EnvPrefix:     spec.EnvPrefix,
 				TagName:       "env",
 				TagDefault:    "envDefault",
+				TagPrefix:     "envPrefix",
+				TagSeparator:  "envSeparator",
 				UseFieldNames: spec.FieldNames,
 			})
 			rend := render.NewRenderer(types.OutFormatTxt, false)
@@ -87,10 +90,13 @@ func extractTxtar(t *testing.T, ar *txtar.Archive) string {
 	return dir
 }
 
-func runGenerator(t *testing.T, gen interface{ Generate(string, io.Writer) error }, spec GenTestSpec, dir string, out *bytes.Buffer) {
+func runGenerator(t *testing.T, gen interface {
+	Generate([]string, io.Writer) error
+}, spec GenTestSpec, dir string, out *bytes.Buffer,
+) {
 	t.Helper()
 
-	if err := gen.Generate(dir, out); err != nil {
+	if err := gen.Generate([]string{dir}, out); err != nil {
 		if spec.Success {
 			t.Fatalf("failed to generate: %s", err)
 		}

--- a/main.go
+++ b/main.go
@@ -29,6 +29,10 @@ func main() {
 		EnvPrefix:       cfg.EnvPrefix,
 		TagName:         cfg.TagName,
 		TagDefault:      cfg.TagDefault,
+		TagPrefix:       cfg.TagPrefix,
+		TagSeparator:    cfg.TagSeparator,
+		TagDescription:  cfg.TagDescription,
+		TagRequired:     cfg.TagRequired,
 		RequiredIfNoDef: cfg.RequiredIfNoDef,
 		UseFieldNames:   cfg.FieldNames,
 	})
@@ -46,7 +50,7 @@ func main() {
 		}
 	}()
 
-	if err := gen.Generate(cfg.Dir, buf); err != nil {
+	if err := gen.Generate(cfg.Dirs, buf); err != nil {
 		fatal("Failed to generate: %v", err)
 	}
 	if err := buf.Flush(); err != nil {

--- a/render/config.go
+++ b/render/config.go
@@ -29,6 +29,18 @@ var configs = map[types.OutFormat]renderConfig{
 		},
 		tmpl: newTmplText("markdown.tmpl"),
 	},
+	types.OutFormatMarkdownTable: {
+		Item: renderItemConfig{
+			SeparatorFormat:  "separated by `%s`",
+			SeparatorDefault: "comma-separated",
+			OptRequired:      "**required**",
+			OptExpand:        "expand",
+			OptFromFile:      "from-file",
+			OptNonEmpty:      "non-empty",
+			EnvDefaultFormat: "default: `%s`",
+		},
+		tmpl: newTmplText("markdown_table.tmpl"),
+	},
 	types.OutFormatHTML: {
 		Item: renderItemConfig{
 			SeparatorFormat:  `separated by "<code>%s</code>"`,

--- a/render/renderer.go
+++ b/render/renderer.go
@@ -41,10 +41,12 @@ type renderSection struct {
 }
 
 type renderItem struct {
-	EnvName      string
-	Doc          string
-	EnvDefault   string
-	EnvSeparator string
+	EnvName        string
+	Doc            string
+	Type           string
+	EnvDefault     string
+	EnvDescription string
+	EnvSeparator   string
 
 	Required bool
 	Expand   bool
@@ -101,15 +103,17 @@ func newRenderItem(item *types.EnvDocItem) renderItem {
 		children[i] = newRenderItem(child)
 	}
 	return renderItem{
-		EnvName:      item.Name,
-		Doc:          item.Doc,
-		EnvDefault:   item.Opts.Default,
-		EnvSeparator: item.Opts.Separator,
-		Required:     item.Opts.Required,
-		Expand:       item.Opts.Expand,
-		NonEmpty:     item.Opts.NonEmpty,
-		FromFile:     item.Opts.FromFile,
-		children:     children,
+		EnvName:        item.Name,
+		Doc:            item.Doc,
+		Type:           item.Type,
+		EnvDefault:     item.Opts.Default,
+		EnvDescription: item.Opts.Description,
+		EnvSeparator:   item.Opts.Separator,
+		Required:       item.Opts.Required,
+		Expand:         item.Opts.Expand,
+		NonEmpty:       item.Opts.NonEmpty,
+		FromFile:       item.Opts.FromFile,
+		children:       children,
 	}
 }
 

--- a/render/templ/html.tmpl
+++ b/render/templ/html.tmpl
@@ -6,7 +6,11 @@
     {{- if $.EnvName -}}
       <code>{{ $.EnvName }}</code>
       {{- template "item.options" (list $ $cfg " (%s)") }}
-      {{- $.Doc | printf " - %s" -}}
+      {{- if $.EnvDescription -}}
+        {{- $.EnvDescription | printf " - %s" -}}
+      {{- else -}}
+        {{- $.Doc | printf " - %s" -}}
+      {{- end }}
     {{- else -}}
       {{- $.Doc | printf "%s" -}}
     {{- end}}

--- a/render/templ/markdown.tmpl
+++ b/render/templ/markdown.tmpl
@@ -6,7 +6,11 @@
   {{- if $.EnvName }}
     {{- $.EnvName | printf "- `%s`" }}
     {{- template "item.options" (list $ $cfg " (%s)") }}
-    {{- $.Doc | printf " - %s" }}
+    {{- if $.EnvDescription }}
+      {{- $.EnvDescription | printf " - %s" }}
+    {{- else }}
+      {{- $.Doc | printf " - %s" }}
+    {{- end }}
   {{- else }}
     {{- $.Doc | printf "- %s" }}
   {{- end }}

--- a/render/templ/markdown_table.tmpl
+++ b/render/templ/markdown_table.tmpl
@@ -1,0 +1,23 @@
+{{- define "item" }}
+  {{- $ := index . 0 }}
+  {{- $cfg := index . 1 }}
+  {{- if $.EnvName }}
+    {{- "|"}} {{ $.EnvName | printf "%s" }} | {{ $.Type | printf "`%s`" }} | {{- if $.EnvDescription }} {{ $.EnvDescription | printf "%s" }} {{- else }} {{ $.Doc | printf "%s" }} {{- end }} | {{ template "item.options" (list $ $cfg "(%s)") }} |
+  {{- end -}}
+{{ end -}}
+
+{{- $cfg := $.Config -}}
+# {{ .Title }}
+{{ range .Sections -}}
+{{ if .Name }}
+## {{ .Name }}
+{{ end }}
+{{- if .Doc }}
+{{ .Doc }}
+{{ end }}
+| env variable | type | description | options |
+|--------------|------|-------------|---------|
+{{ range $item := .Items }}
+{{- template "item" (list $item $cfg.Item 1) }}
+{{ end -}}
+{{ end }}

--- a/render/templ/plaintext.tmpl
+++ b/render/templ/plaintext.tmpl
@@ -6,7 +6,11 @@
   {{- if $.EnvName }}
     {{- $.EnvName | printf "* `%s`" -}}
     {{- template "item.options" (list $ $cfg " (%s)") }}
-    {{- $.Doc | printf " - %s" }}
+    {{- if $.EnvDescription }}
+      {{- $.EnvDescription | printf " - %s" }}
+    {{- else }}
+      {{- $.Doc | printf " - %s" }}
+    {{- end }}
   {{- else }}
     {{- $.Doc | printf "* %s" }}
   {{- end }}

--- a/types/model.go
+++ b/types/model.go
@@ -4,10 +4,11 @@ package types
 type OutFormat string
 
 const (
-	OutFormatMarkdown OutFormat = "markdown"
-	OutFormatHTML     OutFormat = "html"
-	OutFormatTxt      OutFormat = "plaintext"
-	OutFormatEnv      OutFormat = "dotenv"
+	OutFormatMarkdown      OutFormat = "markdown"
+	OutFormatMarkdownTable OutFormat = "markdown-table"
+	OutFormatHTML          OutFormat = "html"
+	OutFormatTxt           OutFormat = "plaintext"
+	OutFormatEnv           OutFormat = "dotenv"
 )
 
 // EnvDocItem is a documentation item for one environment variable.
@@ -18,6 +19,8 @@ type EnvDocItem struct {
 	Doc string
 	// Opts is a set of options for environment variable parsing.
 	Opts EnvVarOptions
+	// Type is a type of environment variable.
+	Type string
 	// Children is a list of child environment variables.
 	Children []*EnvDocItem
 }
@@ -45,4 +48,6 @@ type EnvVarOptions struct {
 	FromFile bool
 	// Default is a default value for the environment variable.
 	Default string
+	// Description is a description value for the environment variable.
+	Description string
 }


### PR DESCRIPTION
@g4s8 Kirill thx for this great tool, trying to adapt it for current workflow.

* Partial compatibility ilyakaznacheev/cleanenv
* Custom tags support for prefix, description, required, separator
* Multi dirs support, to resolve types from other projects
* Markdown-table template
* Support var type in templates

Fix: https://github.com/g4s8/envdoc/issues/28
