### PR TITLE
fix: process envDefault correctly

### DIFF
--- a/_examples/full/config.go
+++ b/_examples/full/config.go
@@ -24,6 +24,9 @@ type ComplexConfig struct {
 
 	Comment string `env:"COMMENT,required" envDefault:"This is a comment."` // Just a comment.
 
+	// AllowMethods is a list of allowed methods.
+	AllowMethods string `env:"ALLOW_METHODS" envDefault:"GET, POST, PUT, PATCH, DELETE, OPTIONS"`
+
 	// Anon is an anonymous structure.
 	Anon struct {
 		// User is a user name.

--- a/_examples/full/doc.md
+++ b/_examples/full/doc.md
@@ -12,8 +12,9 @@ It is trying to cover all the possible cases.
  - `SECRET_KEY` (**required**) - Key is a secret key.
  - `SECRET_VAL` (**required**, non-empty) - SecretVal is a secret value.
  - `HOSTS` (separated by `:`, **required**) - Hosts is a list of hosts.
- - `WORDS` (comma-separated, from-file, default: `one`) - Words is just a list of words.
+ - `WORDS` (comma-separated, from-file, default: `one,two,three`) - Words is just a list of words.
  - `COMMENT` (**required**, default: `This is a comment.`) - Just a comment.
+ - `ALLOW_METHODS` (default: `GET, POST, PUT, PATCH, DELETE, OPTIONS`) - AllowMethods is a list of allowed methods.
  - `ANON_USER` (**required**) - User is a user name.
  - `ANON_PASS` (**required**) - Pass is a password.
 

--- a/converter_test.go
+++ b/converter_test.go
@@ -44,7 +44,7 @@ func TestConvertDocItems(t *testing.T) {
 				Kind: ast.FieldTypeIdent,
 			},
 			Doc: "Field with default",
-			Tag: `env:"FIELD_DEF" envDefault:"envdef"`,
+			Tag: `env:"FIELD_DEF" envDefault:"envdef,envdef2"`,
 		},
 		{
 			Names: []string{"FieldArr"},
@@ -168,7 +168,7 @@ func TestConvertDocItems(t *testing.T) {
 			Name: "FIELD_DEF",
 			Doc:  "Field with default",
 			Opts: types.EnvVarOptions{
-				Default: "envdef",
+				Default: "envdef,envdef2",
 			},
 		},
 		{

--- a/field_decoder.go
+++ b/field_decoder.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/g4s8/envdoc/ast"
 	"github.com/g4s8/envdoc/tags"
 	"github.com/g4s8/envdoc/types"
@@ -79,9 +81,10 @@ func (d *caarlos0fieldDecoder) decodeTagValues(_ *ast.FieldSpec, tag *tags.Field
 }
 
 func (d *caarlos0fieldDecoder) decodeEnvDefault(_ *ast.FieldSpec, tag *tags.FieldTag, out *FieldInfo) {
-	if envDefault, ok := tag.GetFirst(d.opts.TagDefault); ok {
-		out.Default = envDefault
-	} else if !ok && d.opts.RequiredIfNoDef {
+	envDefault := tag.GetAll(d.opts.TagDefault)
+	if len(envDefault) > 0 {
+		out.Default = strings.Join(envDefault, ",")
+	} else if d.opts.RequiredIfNoDef {
 		out.Required = true
 	}
 }

--- a/tags/tags_test.go
+++ b/tags/tags_test.go
@@ -77,6 +77,11 @@ func TestFieldTagValues(t *testing.T) {
 			expect: []string{"password"},
 		},
 		{
+			tag:    `envDefault:"GET, POST, PUT, PATCH, DELETE, OPTIONS"`,
+			key:    "envDefault",
+			expect: []string{"GET", " POST", " PUT", " PATCH", " DELETE", " OPTIONS"},
+		},
+		{
 			tag: `jsonpassword`,
 			key: "json",
 			err: true,


### PR DESCRIPTION
Handle comas in `envDefault`

Fix: #63