### PR TITLE
feat: implement inplace edit

### DIFF
--- a/_examples/edit/README.md
+++ b/_examples/edit/README.md
@@ -1,0 +1,93 @@
+# Server Application
+
+This example demonstrates the **in-place editing feature** of envdoc using the `-edit` flag.
+
+## Overview
+
+When using `-edit` mode, envdoc searches for HTML comment markers in your README file:
+- `envdoc:begin` - marks the start of the generated section
+- `envdoc:end` - marks the end of the generated section
+
+All content between these markers will be replaced with newly generated documentation,
+while everything else in the file remains unchanged. This allows you to maintain
+environment variable documentation alongside other content in your README.
+
+## Features
+
+- HTTP/HTTPS server
+- Database connectivity
+- Configurable connection limits
+- Debug logging
+
+## Environment Variables
+
+The following environment variables configure the server application:
+
+<!--envdoc:begin-->
+# Environment Variables
+
+## ServerConfig
+
+ServerConfig is the server configuration structure.
+This example demonstrates using envdoc in edit mode to
+maintain documentation directly within a README file.
+
+ - `SERVER_HOST` (default: `localhost`) - Host is the server hostname or IP address to bind to.
+ - `SERVER_PORT` (**required**) - Port is the server port number.
+ - TLS configuration
+   - `TLS_ENABLED` (default: `false`) - Enabled turns on TLS/SSL.
+   - `TLS_CERT_FILE` - CertFile is the path to the TLS certificate file.
+   - `TLS_KEY_FILE` - KeyFile is the path to the TLS private key file.
+ - `DATABASE_URL` (**required**) - Database connection string.
+ - `DEBUG` (default: `false`) - Debug enables debug logging when set to true.
+ - `MAX_CONNECTIONS` (default: `100`) - MaxConnections limits the number of concurrent connections.
+
+<!--envdoc:end-->
+
+## Usage
+
+```bash
+# Set required environment variables
+export SERVER_PORT=8080
+export DATABASE_URL=postgres://localhost/mydb
+
+# Optional configuration
+export SERVER_HOST=0.0.0.0
+export DEBUG=true
+export MAX_CONNECTIONS=200
+
+# TLS configuration (optional)
+export TLS_ENABLED=true
+export TLS_CERT_FILE=/path/to/cert.pem
+export TLS_KEY_FILE=/path/to/key.pem
+
+# Run the server
+./server
+```
+
+## Development
+
+To regenerate the environment variable documentation after modifying `config.go`:
+
+```bash
+go generate ./...
+```
+
+The `//go:generate` directive in `config.go` uses the `-edit` flag to update
+only the content between the HTML comment markers, preserving all other
+documentation in this README.
+
+## How It Works
+
+The `config.go` file contains:
+
+```go
+//go:generate go run ../../ -edit -output README.md -format markdown
+```
+
+When you run `go generate`, envdoc:
+1. Parses the struct definitions and their `env` tags
+2. Generates markdown documentation
+3. Finds the markers in README.md
+4. Replaces only the content between the markers
+5. Preserves everything else in the file

--- a/_examples/edit/config.go
+++ b/_examples/edit/config.go
@@ -1,0 +1,38 @@
+package main
+
+// ServerConfig is the server configuration structure.
+// This example demonstrates using envdoc in edit mode to
+// maintain documentation directly within a README file.
+//
+//go:generate go run ../../ -edit -output README.md -format markdown
+type ServerConfig struct {
+	// Host is the server hostname or IP address to bind to.
+	Host string `env:"SERVER_HOST" envDefault:"localhost"`
+
+	// Port is the server port number.
+	Port int `env:"SERVER_PORT,required"`
+
+	// TLS configuration
+	TLS TLSConfig `envPrefix:"TLS_"`
+
+	// Database connection string.
+	DatabaseURL string `env:"DATABASE_URL,required"`
+
+	// Debug enables debug logging when set to true.
+	Debug bool `env:"DEBUG" envDefault:"false"`
+
+	// MaxConnections limits the number of concurrent connections.
+	MaxConnections int `env:"MAX_CONNECTIONS" envDefault:"100"`
+}
+
+// TLSConfig contains TLS/SSL configuration.
+type TLSConfig struct {
+	// Enabled turns on TLS/SSL.
+	Enabled bool `env:"ENABLED" envDefault:"false"`
+
+	// CertFile is the path to the TLS certificate file.
+	CertFile string `env:"CERT_FILE"`
+
+	// KeyFile is the path to the TLS private key file.
+	KeyFile string `env:"KEY_FILE"`
+}

--- a/config.go
+++ b/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	EnvPrefix string
 	// NoStyles to disable styles for HTML format
 	NoStyles bool
+	// Edit enables in-place editing mode (replaces content between markers)
+	Edit bool
 	// FieldNames flag enables field names usage intead of `env` tag.
 	FieldNames bool
 	// Target is the target type
@@ -61,6 +63,7 @@ func (c *Config) parseFlags(f *flag.FlagSet) error {
 	f.StringVar(&c.OutFile, "output", "", "Output file path")
 	f.StringVar((*string)(&c.OutFormat), "format", "markdown", "Output format, default `markdown`")
 	f.BoolVar(&c.NoStyles, "no-styles", false, "Disable styles for HTML output")
+	f.BoolVar(&c.Edit, "edit", false, "Enable in-place editing mode (replaces content between markers)")
 	// app config flags
 	f.StringVar(&c.EnvPrefix, "env-prefix", "", "Environment variable prefix")
 	f.BoolVar(&c.FieldNames, "field-names", false, "Use field names if tag is not specified")
@@ -174,6 +177,9 @@ func (c *Config) fprint(out io.Writer) {
 	if c.NoStyles {
 		fmt.Fprintln(out, "  NoStyles: true")
 	}
+	if c.Edit {
+		fmt.Fprintln(out, "  Edit: true")
+	}
 	fmt.Printf("  ExecFile: %q\n", c.ExecFile)
 	fmt.Printf("  ExecLine: %d\n", c.ExecLine)
 	if c.FieldNames {
@@ -194,5 +200,18 @@ func (c *Config) Load() error {
 	}
 	c.setDefaults()
 	c.normalize()
+	return nil
+}
+
+func (c *Config) Validate() error {
+	if c.Edit {
+		if c.OutFormat != "markdown" {
+			return fmt.Errorf("edit mode (-edit) only supports markdown format, got: %s", c.OutFormat)
+		}
+		if c.OutFile == "" {
+			return errors.New("edit mode (-edit) requires -output flag to be specified")
+		}
+	}
+
 	return nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -53,4 +53,11 @@ func TestConfig(t *testing.T) {
 			t.Errorf("unexpected FileGlob: %q", c.FileGlob)
 		}
 	})
+	t.Run("validate", func(t *testing.T) {
+		var c Config
+		c.Edit = true
+		c.OutFormat = "text"
+		err := c.Validate()
+		testutils.AssertError(t, err != nil, "expected error for invalid config")
+	})
 }

--- a/edit/editor.go
+++ b/edit/editor.go
@@ -1,0 +1,146 @@
+package edit
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	MarkerBegin = "<!--envdoc:begin-->"
+	MarkerEnd   = "<!--envdoc:end-->"
+)
+
+// Editor handles in-place editing of files with marker-based content replacement
+type Editor struct {
+	filePath string
+}
+
+// NewEditor creates a new Editor for the specified file path
+func NewEditor(filePath string) *Editor {
+	return &Editor{
+		filePath: filePath,
+	}
+}
+
+// ReplaceSection replaces the content between markers with newContent.
+// If the file doesn't exist, it creates a new file with markers wrapping the content.
+// If the file exists, it finds the markers and replaces only the content between them.
+func (e *Editor) ReplaceSection(newContent []byte) error {
+	// Check if file exists
+	_, err := os.Stat(e.filePath)
+	if os.IsNotExist(err) {
+		return e.createFileWithMarkers(newContent)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	return e.replaceInExistingFile(newContent)
+}
+
+func (e *Editor) createFileWithMarkers(content []byte) error {
+	dir := filepath.Dir(e.filePath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	var buf bytes.Buffer
+	buf.WriteString(MarkerBegin)
+	buf.WriteString("\n")
+	buf.Write(content)
+	if len(content) > 0 && content[len(content)-1] != '\n' {
+		buf.WriteString("\n")
+	}
+	buf.WriteString(MarkerEnd)
+	buf.WriteString("\n")
+
+	return e.atomicWrite(buf.Bytes())
+}
+
+func validateMarkers(content []byte, beginIdx, endIdx int) error {
+	if beginIdx == -1 && endIdx == -1 {
+		return fmt.Errorf("no markers found in file: missing both %s and %s", MarkerBegin, MarkerEnd)
+	}
+	if beginIdx == -1 {
+		return fmt.Errorf("missing begin marker: %s", MarkerBegin)
+	}
+	if endIdx == -1 {
+		return fmt.Errorf("missing end marker: %s", MarkerEnd)
+	}
+	if beginIdx >= endIdx {
+		return fmt.Errorf("markers in wrong order: begin marker must come before end marker")
+	}
+
+	// Check for duplicate markers
+	if bytes.Count(content, []byte(MarkerBegin)) > 1 {
+		return fmt.Errorf("duplicate begin markers found: %s appears more than once", MarkerBegin)
+	}
+	if bytes.Count(content, []byte(MarkerEnd)) > 1 {
+		return fmt.Errorf("duplicate end markers found: %s appears more than once", MarkerEnd)
+	}
+
+	return nil
+}
+
+func (e *Editor) replaceInExistingFile(newContent []byte) error {
+	existingContent, err := os.ReadFile(e.filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	beginIdx := bytes.Index(existingContent, []byte(MarkerBegin))
+	endIdx := bytes.Index(existingContent, []byte(MarkerEnd))
+
+	if err := validateMarkers(existingContent, beginIdx, endIdx); err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+
+	buf.Write(existingContent[:beginIdx])
+	buf.WriteString(MarkerBegin)
+	buf.WriteString("\n")
+	buf.Write(newContent)
+	if len(newContent) > 0 && newContent[len(newContent)-1] != '\n' {
+		buf.WriteString("\n")
+	}
+	endMarkerStart := endIdx
+	buf.Write(existingContent[endMarkerStart:])
+
+	return e.atomicWrite(buf.Bytes())
+}
+
+// atomicWrite writes content to a temp file then renames it to the target path
+// This prevents corruption if the write fails partway through
+func (e *Editor) atomicWrite(content []byte) error {
+	dir := filepath.Dir(e.filePath)
+	tmpFile, err := os.CreateTemp(dir, ".envdoc-*.tmp")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+
+	defer func() {
+		if tmpFile != nil {
+			tmpFile.Close()
+			os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmpFile.Write(content); err != nil {
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, e.filePath); err != nil {
+		return fmt.Errorf("failed to rename temp file: %w", err)
+	}
+
+	tmpFile = nil
+	return nil
+}

--- a/edit/editor_test.go
+++ b/edit/editor_test.go
@@ -1,0 +1,640 @@
+package edit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEditor_ReplaceSection_CreateNewFile(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.md")
+
+	// Create editor
+	editor := NewEditor(filePath)
+
+	// Replace section (file doesn't exist yet)
+	content := []byte("# Generated Content\n\nThis is the generated documentation.\n")
+	if err := editor.ReplaceSection(content); err != nil {
+		t.Fatalf("ReplaceSection failed: %v", err)
+	}
+
+	// Read result
+	result, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read result file: %v", err)
+	}
+
+	// Verify structure
+	resultStr := string(result)
+	if !strings.Contains(resultStr, MarkerBegin) {
+		t.Errorf("Result missing begin marker")
+	}
+	if !strings.Contains(resultStr, MarkerEnd) {
+		t.Errorf("Result missing end marker")
+	}
+	if !strings.Contains(resultStr, "# Generated Content") {
+		t.Errorf("Result missing generated content")
+	}
+
+	// Verify order
+	beginIdx := strings.Index(resultStr, MarkerBegin)
+	endIdx := strings.Index(resultStr, MarkerEnd)
+	contentIdx := strings.Index(resultStr, "# Generated Content")
+	if beginIdx >= contentIdx || contentIdx >= endIdx {
+		t.Errorf("Markers not in correct order: begin=%d, content=%d, end=%d", beginIdx, contentIdx, endIdx)
+	}
+}
+
+func TestEditor_ReplaceSection_BasicReplacement(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.md")
+
+	// Create initial file with markers
+	initialContent := `# My README
+
+Some intro text.
+
+<!--envdoc:begin-->
+Old generated content
+<!--envdoc:end-->
+
+Some footer text.
+`
+	if err := os.WriteFile(filePath, []byte(initialContent), 0o644); err != nil {
+		t.Fatalf("Failed to create initial file: %v", err)
+	}
+
+	// Create editor
+	editor := NewEditor(filePath)
+
+	// Replace section
+	newContent := []byte("# New Generated Content\n\nThis is updated.\n")
+	if err := editor.ReplaceSection(newContent); err != nil {
+		t.Fatalf("ReplaceSection failed: %v", err)
+	}
+
+	// Read result
+	result, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read result file: %v", err)
+	}
+
+	resultStr := string(result)
+
+	// Verify content before markers is preserved
+	if !strings.Contains(resultStr, "# My README") {
+		t.Errorf("Content before markers was not preserved")
+	}
+	if !strings.Contains(resultStr, "Some intro text.") {
+		t.Errorf("Content before markers was not preserved")
+	}
+
+	// Verify new content is present
+	if !strings.Contains(resultStr, "# New Generated Content") {
+		t.Errorf("New content not found")
+	}
+	if !strings.Contains(resultStr, "This is updated.") {
+		t.Errorf("New content not found")
+	}
+
+	// Verify old content is gone
+	if strings.Contains(resultStr, "Old generated content") {
+		t.Errorf("Old content was not replaced")
+	}
+
+	// Verify content after markers is preserved
+	if !strings.Contains(resultStr, "Some footer text.") {
+		t.Errorf("Content after markers was not preserved")
+	}
+}
+
+func TestEditor_ReplaceSection_EmptyContent(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.md")
+
+	// Create initial file with markers
+	initialContent := `# README
+
+<!--envdoc:begin-->
+Content to be removed
+<!--envdoc:end-->
+
+Footer.
+`
+	if err := os.WriteFile(filePath, []byte(initialContent), 0o644); err != nil {
+		t.Fatalf("Failed to create initial file: %v", err)
+	}
+
+	// Create editor
+	editor := NewEditor(filePath)
+
+	// Replace with empty content
+	if err := editor.ReplaceSection([]byte{}); err != nil {
+		t.Fatalf("ReplaceSection failed: %v", err)
+	}
+
+	// Read result
+	result, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read result file: %v", err)
+	}
+
+	resultStr := string(result)
+
+	// Verify markers still present
+	if !strings.Contains(resultStr, MarkerBegin) {
+		t.Errorf("Begin marker missing")
+	}
+	if !strings.Contains(resultStr, MarkerEnd) {
+		t.Errorf("End marker missing")
+	}
+
+	// Verify old content is gone
+	if strings.Contains(resultStr, "Content to be removed") {
+		t.Errorf("Old content was not removed")
+	}
+
+	// Verify other content preserved
+	if !strings.Contains(resultStr, "# README") {
+		t.Errorf("Header not preserved")
+	}
+	if !strings.Contains(resultStr, "Footer.") {
+		t.Errorf("Footer not preserved")
+	}
+}
+
+func TestEditor_ReplaceSection_MissingMarkers(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name:    "no markers",
+			content: "# README\n\nNo markers here.\n",
+			wantErr: "no markers found",
+		},
+		{
+			name:    "only begin marker",
+			content: "# README\n\n<!--envdoc:begin-->\n\nNo end marker.\n",
+			wantErr: "missing end marker",
+		},
+		{
+			name:    "only end marker",
+			content: "# README\n\nNo begin marker.\n\n<!--envdoc:end-->\n",
+			wantErr: "missing begin marker",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp directory
+			tmpDir := t.TempDir()
+			filePath := filepath.Join(tmpDir, "test.md")
+
+			// Create file with test content
+			if err := os.WriteFile(filePath, []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("Failed to create test file: %v", err)
+			}
+
+			// Create editor
+			editor := NewEditor(filePath)
+
+			// Attempt to replace section
+			err := editor.ReplaceSection([]byte("new content"))
+			if err == nil {
+				t.Fatalf("Expected error but got none")
+			}
+
+			// Verify error message
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestEditor_ReplaceSection_MarkersWrongOrder(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.md")
+
+	// Create file with markers in wrong order
+	content := `# README
+
+<!--envdoc:end-->
+Content
+<!--envdoc:begin-->
+
+Footer.
+`
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Create editor
+	editor := NewEditor(filePath)
+
+	// Attempt to replace section
+	err := editor.ReplaceSection([]byte("new content"))
+	if err == nil {
+		t.Fatalf("Expected error but got none")
+	}
+
+	// Verify error message
+	if !strings.Contains(err.Error(), "wrong order") {
+		t.Errorf("Expected error about wrong order, got: %v", err)
+	}
+}
+
+func TestEditor_ReplaceSection_DuplicateMarkers(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{
+			name: "duplicate begin markers",
+			content: `# README
+
+<!--envdoc:begin-->
+Section 1
+<!--envdoc:end-->
+
+<!--envdoc:begin-->
+Section 2
+<!--envdoc:end-->
+`,
+			wantErr: "duplicate begin markers",
+		},
+		{
+			name: "duplicate end markers",
+			content: `# README
+
+<!--envdoc:begin-->
+Section
+<!--envdoc:end-->
+More content
+<!--envdoc:end-->
+`,
+			wantErr: "duplicate end markers",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp directory
+			tmpDir := t.TempDir()
+			filePath := filepath.Join(tmpDir, "test.md")
+
+			// Create file with test content
+			if err := os.WriteFile(filePath, []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("Failed to create test file: %v", err)
+			}
+
+			// Create editor
+			editor := NewEditor(filePath)
+
+			// Attempt to replace section
+			err := editor.ReplaceSection([]byte("new content"))
+			if err == nil {
+				t.Fatalf("Expected error but got none")
+			}
+
+			// Verify error message
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestEditor_ReplaceSection_MultilineContent(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.md")
+
+	// Create initial file
+	initialContent := `# Project README
+
+This is the introduction.
+
+<!--envdoc:begin-->
+Old docs
+<!--envdoc:end-->
+
+## Other Section
+
+This should be preserved.
+`
+	if err := os.WriteFile(filePath, []byte(initialContent), 0o644); err != nil {
+		t.Fatalf("Failed to create initial file: %v", err)
+	}
+
+	// Create editor
+	editor := NewEditor(filePath)
+
+	// Replace with multiline content
+	newContent := `## Environment Variables
+
+### PORT
+
+**Type**: int
+
+**Default**: 8080
+
+**Description**: Server port
+
+### DATABASE_URL
+
+**Type**: string
+
+**Required**: Yes
+
+**Description**: Database connection string
+`
+	if err := editor.ReplaceSection([]byte(newContent)); err != nil {
+		t.Fatalf("ReplaceSection failed: %v", err)
+	}
+
+	// Read result
+	result, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read result file: %v", err)
+	}
+
+	resultStr := string(result)
+
+	// Verify all sections present
+	requiredSections := []string{
+		"# Project README",
+		"This is the introduction.",
+		MarkerBegin,
+		"## Environment Variables",
+		"### PORT",
+		"### DATABASE_URL",
+		MarkerEnd,
+		"## Other Section",
+		"This should be preserved.",
+	}
+
+	for _, section := range requiredSections {
+		if !strings.Contains(resultStr, section) {
+			t.Errorf("Missing required section: %q", section)
+		}
+	}
+
+	// Verify old content is gone
+	if strings.Contains(resultStr, "Old docs") {
+		t.Errorf("Old content was not replaced")
+	}
+}
+
+func TestEditor_ReplaceSection_CreateInSubdirectory(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "subdir", "nested", "test.md")
+
+	// Create editor
+	editor := NewEditor(filePath)
+
+	// Replace section (directories don't exist yet)
+	content := []byte("# Content\n")
+	if err := editor.ReplaceSection(content); err != nil {
+		t.Fatalf("ReplaceSection failed: %v", err)
+	}
+
+	// Verify file was created
+	if _, err := os.Stat(filePath); err != nil {
+		t.Fatalf("File was not created: %v", err)
+	}
+
+	// Read and verify content
+	result, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read result file: %v", err)
+	}
+
+	resultStr := string(result)
+	if !strings.Contains(resultStr, MarkerBegin) || !strings.Contains(resultStr, MarkerEnd) {
+		t.Errorf("Markers not found in created file")
+	}
+	if !strings.Contains(resultStr, "# Content") {
+		t.Errorf("Content not found in created file")
+	}
+}
+
+func TestEditor_ReplaceSection_ContentWithoutTrailingNewline(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.md")
+
+	// Create initial file with markers
+	initialContent := `# README
+
+<!--envdoc:begin-->
+Old content
+<!--envdoc:end-->
+
+Footer.
+`
+	if err := os.WriteFile(filePath, []byte(initialContent), 0o644); err != nil {
+		t.Fatalf("Failed to create initial file: %v", err)
+	}
+
+	// Create editor
+	editor := NewEditor(filePath)
+
+	// Replace with content that doesn't end with newline
+	newContent := []byte("New content without trailing newline")
+	if err := editor.ReplaceSection(newContent); err != nil {
+		t.Fatalf("ReplaceSection failed: %v", err)
+	}
+
+	// Read result
+	result, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read result file: %v", err)
+	}
+
+	resultStr := string(result)
+
+	// Verify new content is present
+	if !strings.Contains(resultStr, "New content without trailing newline") {
+		t.Errorf("New content not found")
+	}
+
+	// Verify markers still present
+	if !strings.Contains(resultStr, MarkerBegin) {
+		t.Errorf("Begin marker missing")
+	}
+	if !strings.Contains(resultStr, MarkerEnd) {
+		t.Errorf("End marker missing")
+	}
+
+	// Verify footer is preserved
+	if !strings.Contains(resultStr, "Footer.") {
+		t.Errorf("Footer not preserved")
+	}
+}
+
+func TestEditor_ReplaceSection_CreateFileWithoutTrailingNewline(t *testing.T) {
+	// Create temp directory
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test.md")
+
+	// Create editor
+	editor := NewEditor(filePath)
+
+	// Create file with content that doesn't end with newline
+	content := []byte("Content without newline")
+	if err := editor.ReplaceSection(content); err != nil {
+		t.Fatalf("ReplaceSection failed: %v", err)
+	}
+
+	// Read result
+	result, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read result file: %v", err)
+	}
+
+	resultStr := string(result)
+
+	// Verify content and markers are present
+	if !strings.Contains(resultStr, "Content without newline") {
+		t.Errorf("Content not found")
+	}
+	if !strings.Contains(resultStr, MarkerBegin) {
+		t.Errorf("Begin marker missing")
+	}
+	if !strings.Contains(resultStr, MarkerEnd) {
+		t.Errorf("End marker missing")
+	}
+
+	// Verify proper structure (newline added after content)
+	if !strings.Contains(resultStr, "Content without newline\n"+MarkerEnd) {
+		t.Errorf("Newline was not added after content")
+	}
+}
+
+func TestEditor_ReplaceSection_StatError(t *testing.T) {
+	// This test is tricky to implement portably since we need to trigger
+	// a stat error that's not os.IsNotExist. We can use a file in a directory
+	// without permissions (on Unix systems)
+	if os.Getuid() == 0 {
+		t.Skip("Skipping test when running as root")
+	}
+
+	tmpDir := t.TempDir()
+
+	// Create a directory without read/execute permissions
+	restrictedDir := filepath.Join(tmpDir, "restricted")
+	if err := os.Mkdir(restrictedDir, 0o000); err != nil {
+		t.Fatalf("Failed to create restricted directory: %v", err)
+	}
+	defer func() {
+		_ = os.Chmod(restrictedDir, 0o755) // Restore permissions for cleanup
+	}()
+
+	filePath := filepath.Join(restrictedDir, "test.md")
+	editor := NewEditor(filePath)
+
+	// Attempt to replace section should fail with stat error
+	err := editor.ReplaceSection([]byte("content"))
+	if err == nil {
+		t.Fatalf("Expected error but got none")
+	}
+
+	if !strings.Contains(err.Error(), "failed to stat file") {
+		t.Errorf("Expected stat error, got: %v", err)
+	}
+}
+
+func TestEditor_ReplaceSection_MkdirError(t *testing.T) {
+	// Create a file where we want to create a directory
+	// This will cause an error when trying to create nested directories
+	if os.Getuid() == 0 {
+		t.Skip("Skipping test when running as root")
+	}
+
+	tmpDir := t.TempDir()
+
+	// Create a regular file
+	blockingFile := filepath.Join(tmpDir, "file")
+	if err := os.WriteFile(blockingFile, []byte("test"), 0o644); err != nil {
+		t.Fatalf("Failed to create blocking file: %v", err)
+	}
+
+	// Try to create a file where we need "file" to be a directory
+	filePath := filepath.Join(blockingFile, "test.md")
+	editor := NewEditor(filePath)
+
+	// Attempt to replace section should fail
+	err := editor.ReplaceSection([]byte("content"))
+	if err == nil {
+		t.Fatalf("Expected error but got none")
+	}
+
+	// The error can be either a stat error (not a directory) or directory creation error
+	// Both are valid since they both prevent creating the file
+	errMsg := err.Error()
+	hasValidError := strings.Contains(errMsg, "failed to create directory") ||
+		strings.Contains(errMsg, "failed to create temp file") ||
+		strings.Contains(errMsg, "failed to stat file") ||
+		strings.Contains(errMsg, "not a directory")
+
+	if !hasValidError {
+		t.Errorf("Expected file system error, got: %v", err)
+	}
+}
+
+func TestEditor_ReplaceSection_WriteToReadOnlyDirectory(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("Skipping test when running as root")
+	}
+
+	tmpDir := t.TempDir()
+	readOnlyDir := filepath.Join(tmpDir, "readonly")
+	if err := os.Mkdir(readOnlyDir, 0o755); err != nil {
+		t.Fatalf("Failed to create directory: %v", err)
+	}
+
+	// Create initial file
+	filePath := filepath.Join(readOnlyDir, "test.md")
+	initialContent := `# README
+
+<!--envdoc:begin-->
+Old content
+<!--envdoc:end-->
+
+Footer.
+`
+	if err := os.WriteFile(filePath, []byte(initialContent), 0o644); err != nil {
+		t.Fatalf("Failed to create initial file: %v", err)
+	}
+
+	// Make directory read-only
+	if err := os.Chmod(readOnlyDir, 0o555); err != nil {
+		t.Fatalf("Failed to change directory permissions: %v", err)
+	}
+	defer func() {
+		_ = os.Chmod(readOnlyDir, 0o755) // Restore for cleanup
+	}()
+
+	editor := NewEditor(filePath)
+
+	// Attempt to replace section should fail (can't create temp file)
+	err := editor.ReplaceSection([]byte("new content"))
+	if err == nil {
+		t.Fatalf("Expected error but got none")
+	}
+
+	if !strings.Contains(err.Error(), "failed to create temp file") {
+		t.Errorf("Expected temp file creation error, got: %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -4,11 +4,13 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"os"
 
 	"github.com/g4s8/envdoc/ast"
 	"github.com/g4s8/envdoc/debug"
+	"github.com/g4s8/envdoc/edit"
 	"github.com/g4s8/envdoc/render"
 )
 
@@ -20,6 +22,9 @@ func main() {
 	if cfg.Debug {
 		debug.Config.Enabled = true
 		cfg.fprint(os.Stdout)
+	}
+	if err := cfg.Validate(); err != nil {
+		fatal("Invalid config: %v", err)
 	}
 
 	parser := ast.NewParser(cfg.FileGlob, cfg.TypeGlob,
@@ -35,17 +40,44 @@ func main() {
 	renderer := render.NewRenderer(cfg.OutFormat, cfg.NoStyles)
 	gen := NewGenerator(parser, converter, renderer)
 
+	// Branch based on mode
+	if cfg.Edit {
+		generateEdit(gen, cfg)
+	} else {
+		generateNormal(gen, cfg)
+	}
+}
+
+// generateEdit generates documentation in edit mode, replacing content between markers
+func generateEdit(gen *Generator, cfg Config) {
+	var buf bytes.Buffer
+	if err := gen.Generate(cfg.Dir, &buf); err != nil {
+		fatal("Failed to generate: %v", err)
+	}
+
+	editor := edit.NewEditor(cfg.OutFile)
+	if err := editor.ReplaceSection(buf.Bytes()); err != nil {
+		fatal("Failed to edit file: %v", err)
+	}
+
+	if cfg.Debug {
+		fmt.Fprintf(os.Stderr, "Successfully updated %s\n", cfg.OutFile)
+	}
+}
+
+// generateNormal generates documentation in normal mode, writing to output file
+func generateNormal(gen *Generator, cfg Config) {
 	out, err := os.Create(cfg.OutFile)
 	if err != nil {
 		fatal("Failed to open output file: %v", err)
 	}
-	buf := bufio.NewWriter(out)
 	defer func() {
 		if err := out.Close(); err != nil {
 			fatal("Failed to close output file: %v", err)
 		}
 	}()
 
+	buf := bufio.NewWriter(out)
 	if err := gen.Generate(cfg.Dir, buf); err != nil {
 		fatal("Failed to generate: %v", err)
 	}


### PR DESCRIPTION
Implement inplace edit mode. To enable edit mode use `-edit` flag. Edit mode supported only by markdown format yet, later html format could also support edit mode.

Edit mode replaces content between html comment markers with generated documentation:
 - `<!--envdoc:begin-->` - start marker
 - `<!--envdoc:end-->` - end marker

See `./_examples/edit` example.

Close: #61 